### PR TITLE
feat: add service-to-location links and update location rollout plan

### DIFF
--- a/docs/seo-geo/prds/04d-location-pages.md
+++ b/docs/seo-geo/prds/04d-location-pages.md
@@ -201,7 +201,8 @@ From the FAQ section on each page.
 
 ## Internal Linking
 
-- **Homepage** → Add all suburb links to the "Service Areas" or a new "Areas We Serve" section.
+- **Homepage** → Add location links under the Services section (as an "Areas We Serve" group beneath services content).
+- **Main menu/navigation** → Add a Locations entry so suburb pages are discoverable from primary navigation.
 - **Suburb pages** → cross-link to nearby suburbs ("Also serving nearby: [links]")
 - **Service pages** → mention service areas with links to relevant location pages (e.g., air conditioning page mentions "We install split systems across Altona, Footscray, and Newport" with links)
 - **Location pages** → link to relevant service pages
@@ -260,19 +261,20 @@ The strategy mirrors the existing `Service Routes` describe block in `packages/s
    - `nav` is visible
 5. Add this as a `Location Routes` describe block in `packages/ses-next/tests/routes.spec.ts`.
 
-## siteSettings Service Areas Migration
+## Service Areas Data Source Migration
 
-The `serviceAreas` string array in Site Settings should be **replaced with references to `locationPage` documents** once all location pages are published. This ensures:
+Service area lists must no longer come from `siteSettings.serviceAreas`. They should come directly from published `locationPage` documents. This ensures:
 
 - Single source of truth — suburbs defined once in `locationPage`
-- Automatic internal linking from any component reading service areas
-- No suburb listed as a service area without a corresponding page
+- No stale suburb strings in Site Settings
+- Automatic linking because each area includes a real location page slug
 
 **Migration steps:**
 
-1. Publish all location pages in Sanity
-2. Update `siteSettings` schema to use `array of references` to `locationPage` instead of `array of string`
-3. Update any component consuming `serviceAreas` to use the location page slug for linking
+1. Publish all required location pages in Sanity
+2. Update frontend sections that currently render service areas (for example services hub and homepage) to query `locationPage` documents instead of reading `siteSettings.serviceAreas`
+3. Remove `serviceAreas` from the `siteSettings` schema
+4. Remove `serviceAreas` from queries, mappings, and types so the field is fully deprecated
 
 ## Acceptance Criteria
 
@@ -289,5 +291,8 @@ The `serviceAreas` string array in Site Settings should be **replaced with refer
 - [x] Services linked to each location page in Sanity Studio
 - [x] Cross-links between suburb pages ("Also serving nearby")
 - [x] Service pages updated with links to relevant location pages
+- [ ] Homepage shows location links under Services section
+- [ ] Main menu includes link to Locations
 - [ ] All new pages appear in sitemap
-- [ ] `siteSettings.serviceAreas` migrated from string array to `locationPage` references
+- [ ] Service area UI sections read from `locationPage` data (not `siteSettings`)
+- [ ] `siteSettings.serviceAreas` removed from schema and frontend data model

--- a/docs/seo-geo/prds/04d-location-pages.md
+++ b/docs/seo-geo/prds/04d-location-pages.md
@@ -288,6 +288,6 @@ The `serviceAreas` string array in Site Settings should be **replaced with refer
 - [x] E2E test added to `routes.spec.ts` as a `Location Routes` describe block (skips gracefully when no pages are published)
 - [x] Services linked to each location page in Sanity Studio
 - [x] Cross-links between suburb pages ("Also serving nearby")
-- [ ] Service pages updated with links to relevant location pages
+- [x] Service pages updated with links to relevant location pages
 - [ ] All new pages appear in sitemap
 - [ ] `siteSettings.serviceAreas` migrated from string array to `locationPage` references

--- a/packages/ses-next/src/app/services/[...slug]/page.tsx
+++ b/packages/ses-next/src/app/services/[...slug]/page.tsx
@@ -4,11 +4,17 @@ import { PortableText } from '@portabletext/react';
 import Link from 'next/link';
 import { googleReviews } from 'ses-reviews';
 
-import { getBlogPosts, getServices, getSiteSettings } from '@/lib/content/contentService';
+import {
+  getBlogPosts,
+  getLocationPagesByServiceSlugs,
+  getServices,
+  getSiteSettings,
+} from '@/lib/content/contentService';
 import { faqJsonLd, safeJsonLd } from '@/lib/structuredData';
 import { CustomImage } from '@/components/CustomImage';
 import { ImageCarousel } from '@/components/ImageCarousel';
 import { RelatedServices } from '@/components/RelatedServices/RelatedServices';
+import { ServiceLocations } from '@/components/ServiceLocations/ServiceLocations';
 import { SanityImage } from '@/components/SanityImage';
 import { ServiceBreadcrumb } from '@/components/ServiceBreadcrumb/ServiceBreadcrumb';
 import type { GoogleReview, ServiceItem } from '@/types';
@@ -100,6 +106,8 @@ export default async function ServicePage({ params }: ServicePageProps) {
 
   const childServices = services.filter((s) => s.parentService?.slug === service!.slug);
   const filteredBlogPosts = blogPosts.filter(({ tags }) => tags.includes(service!.slug));
+  const serviceSlugs = service.parentService ? [service.slug, service.parentService.slug] : [service.slug];
+  const locationPages = await getLocationPagesByServiceSlugs(serviceSlugs);
 
   const { baseUrl, companyName, phone, companyLogo } = siteSettings;
   const servicesUrl = new URL('services/', baseUrl).toString();
@@ -200,6 +208,8 @@ export default async function ServicePage({ params }: ServicePageProps) {
         {service.imageGallery && <ImageCarousel images={service.imageGallery} serviceName={service.name} />}
 
         {childServices.length > 0 && <RelatedServices services={childServices} />}
+
+        {locationPages.length > 0 && <ServiceLocations serviceName={service.name} locations={locationPages} />}
 
         {service.faqs && service.faqs.length > 0 && (
           <section aria-labelledby="faq-heading" className="mx-auto mt-12 mb-8 max-w-screen-lg px-4 md:px-8">

--- a/packages/ses-next/src/app/services/[...slug]/page.tsx
+++ b/packages/ses-next/src/app/services/[...slug]/page.tsx
@@ -17,7 +17,7 @@ import { RelatedServices } from '@/components/RelatedServices/RelatedServices';
 import { ServiceLocations } from '@/components/ServiceLocations/ServiceLocations';
 import { SanityImage } from '@/components/SanityImage';
 import { ServiceBreadcrumb } from '@/components/ServiceBreadcrumb/ServiceBreadcrumb';
-import type { GoogleReview, ServiceItem } from '@/types';
+import type { GoogleReview, LocationPageNearbySuburbRef, ServiceItem } from '@/types';
 
 type ServicePageProps = {
   params: Promise<{ slug: string[] }>;
@@ -107,7 +107,13 @@ export default async function ServicePage({ params }: ServicePageProps) {
   const childServices = services.filter((s) => s.parentService?.slug === service!.slug);
   const filteredBlogPosts = blogPosts.filter(({ tags }) => tags.includes(service!.slug));
   const serviceSlugs = service.parentService ? [service.slug, service.parentService.slug] : [service.slug];
-  const locationPages = await getLocationPagesByServiceSlugs(serviceSlugs);
+  let locationPages: LocationPageNearbySuburbRef[] = [];
+
+  try {
+    locationPages = await getLocationPagesByServiceSlugs(serviceSlugs);
+  } catch (error) {
+    console.error('Failed to fetch location pages for service page:', error);
+  }
 
   const { baseUrl, companyName, phone, companyLogo } = siteSettings;
   const servicesUrl = new URL('services/', baseUrl).toString();

--- a/packages/ses-next/src/components/ServiceLocations/ServiceLocations.tsx
+++ b/packages/ses-next/src/components/ServiceLocations/ServiceLocations.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+
+import type { LocationPageNearbySuburbRef } from '@/types';
+
+type ServiceLocationsProps = {
+  serviceName: string;
+  locations: LocationPageNearbySuburbRef[];
+};
+
+export function ServiceLocations({ serviceName, locations }: ServiceLocationsProps) {
+  return (
+    <section aria-labelledby="service-locations-heading" className="mx-auto mt-12 mb-8 max-w-screen-lg px-4 md:px-8">
+      <h2 id="service-locations-heading" className="mb-3 text-3xl font-bold text-gray-900">
+        Areas We Serve for {serviceName}
+      </h2>
+      <p className="mb-6 text-gray-600">
+        We regularly deliver {serviceName.toLowerCase()} across these suburbs in Melbourne&apos;s west.
+      </p>
+      <ul className="flex flex-wrap gap-3" aria-label={`${serviceName} service areas`}>
+        {locations.map((location) => (
+          <li key={location.id}>
+            <Link
+              href={`/locations/${location.slug}`}
+              className="hover:bg-primary hover:border-primary inline-flex items-center rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-800 transition-colors hover:text-white"
+              prefetch={false}
+            >
+              Electrician {location.suburb}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/packages/ses-next/src/components/ServiceLocations/ServiceLocations.tsx
+++ b/packages/ses-next/src/components/ServiceLocations/ServiceLocations.tsx
@@ -7,28 +7,72 @@ type ServiceLocationsProps = {
   locations: LocationPageNearbySuburbRef[];
 };
 
+const sectionDescription =
+  "Our team is on the road every day across Melbourne's west. Choose a suburb page for local availability and suburb-specific guidance.";
+
+const cardAccentClasses = [
+  'from-sky-400/30 via-cyan-300/10 to-transparent',
+  'from-emerald-400/30 via-teal-300/10 to-transparent',
+  'from-amber-400/30 via-orange-300/10 to-transparent',
+  'from-rose-400/30 via-pink-300/10 to-transparent',
+];
+
+const getCardAccentClass = (index: number): string => {
+  return cardAccentClasses[index % cardAccentClasses.length];
+};
+
+const getCardSpanClass = (index: number): string => {
+  return index === 0 ? 'xl:col-span-2' : '';
+};
+
 export function ServiceLocations({ serviceName, locations }: ServiceLocationsProps) {
   return (
-    <section aria-labelledby="service-locations-heading" className="mx-auto mt-12 mb-8 max-w-screen-lg px-4 md:px-8">
-      <h2 id="service-locations-heading" className="mb-3 text-3xl font-bold text-gray-900">
-        Areas We Serve for {serviceName}
-      </h2>
-      <p className="mb-6 text-gray-600">
-        We regularly deliver {serviceName.toLowerCase()} across these suburbs in Melbourne&apos;s west.
-      </p>
-      <ul className="flex flex-wrap gap-3" aria-label={`${serviceName} service areas`}>
-        {locations.map((location) => (
-          <li key={location.id}>
-            <Link
-              href={`/locations/${location.slug}`}
-              className="hover:bg-primary hover:border-primary inline-flex items-center rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-800 transition-colors hover:text-white"
-              prefetch={false}
-            >
-              Electrician {location.suburb}
-            </Link>
-          </li>
-        ))}
-      </ul>
+    <section aria-labelledby="service-locations-heading" className="mx-auto mt-14 mb-10 max-w-screen-xl px-4 md:px-8">
+      <div className="relative overflow-hidden rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800 px-6 py-10 text-white shadow-2xl shadow-slate-900/35 sm:px-8 lg:px-10">
+        <div className="absolute -top-16 -right-10 h-44 w-44 rounded-full bg-cyan-300/20 blur-3xl" />
+        <div className="absolute -bottom-20 -left-10 h-56 w-56 rounded-full bg-emerald-300/15 blur-3xl" />
+        <div className="absolute inset-0 [background-image:radial-gradient(rgba(255,255,255,0.55)_1px,transparent_1px)] [background-size:14px_14px] opacity-20" />
+
+        <div className="relative">
+          <p className="mb-4 inline-flex rounded-full border border-white/25 bg-white/10 px-3 py-1 text-xs font-semibold tracking-[0.18em] uppercase">
+            Area Coverage
+          </p>
+          <h2 id="service-locations-heading" className="max-w-3xl text-3xl leading-tight font-bold sm:text-4xl">
+            {serviceName} across Melbourne&apos;s west
+          </h2>
+          <p className="mt-4 max-w-3xl text-base leading-7 text-slate-200">{sectionDescription}</p>
+
+          <ul
+            className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3"
+            aria-label={`${serviceName} service areas`}
+          >
+            {locations.map((location, index) => (
+              <li key={location.id} className={getCardSpanClass(index)}>
+                <Link
+                  href={`/locations/${location.slug}`}
+                  className="group relative flex h-full flex-col justify-between overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-5 backdrop-blur-sm transition duration-200 hover:-translate-y-1 hover:border-white/45 hover:bg-white/15"
+                  prefetch={false}
+                >
+                  <div
+                    className={`absolute inset-x-0 top-0 h-1.5 bg-gradient-to-r ${getCardAccentClass(index)} transition-opacity duration-200 group-hover:opacity-100`}
+                  />
+                  <div>
+                    <p className="text-xs font-semibold tracking-[0.14em] text-cyan-100 uppercase">
+                      Local service page
+                    </p>
+                    <h3 className="mt-3 text-2xl leading-tight font-semibold text-white">
+                      Electrician {location.suburb}
+                    </h3>
+                  </div>
+                  <p className="mt-7 text-sm font-medium text-slate-200 transition-colors group-hover:text-white">
+                    Explore local details and availability
+                  </p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
     </section>
   );
 }

--- a/packages/ses-next/src/components/ServiceLocations/ServiceLocations.tsx
+++ b/packages/ses-next/src/components/ServiceLocations/ServiceLocations.tsx
@@ -60,9 +60,7 @@ export function ServiceLocations({ serviceName, locations }: ServiceLocationsPro
                     <p className="text-xs font-semibold tracking-[0.14em] text-cyan-100 uppercase">
                       Local service page
                     </p>
-                    <h3 className="mt-3 text-2xl leading-tight font-semibold text-white">
-                      Electrician {location.suburb}
-                    </h3>
+                    <h3 className="mt-3 text-2xl leading-tight font-semibold text-white">{location.suburb}</h3>
                   </div>
                   <p className="mt-7 text-sm font-medium text-slate-200 transition-colors group-hover:text-white">
                     Explore local details and availability

--- a/packages/ses-next/src/lib/content/contentService.ts
+++ b/packages/ses-next/src/lib/content/contentService.ts
@@ -3,6 +3,7 @@ import { config } from '@/lib/config';
 import {
   type BlogPost,
   type LocationPage,
+  type LocationPageNearbySuburbRef,
   type SiteSettings,
   type ServiceItem,
   type HomePageContent,
@@ -18,6 +19,7 @@ import {
   ServiceSchema,
   BlogPostSchema,
   FAQSchema,
+  LocationPageNearbySuburbRefSchema,
   TermsAndConditionsSchema,
 } from '@/types';
 import {
@@ -35,6 +37,7 @@ import {
   allLocationPagesQuery,
   homepageQuery,
   locationPageBySlugQuery,
+  locationPagesByServiceSlugsQuery,
   servicesHubQuery,
   servicesQuery,
   siteSettingsQuery,
@@ -188,5 +191,28 @@ export const getLocationPageBySlug = async (slug: string): Promise<LocationPage 
   } catch (error) {
     console.error('Error in getLocationPageBySlug:', error);
     throw new Error('Failed to fetch location page');
+  }
+};
+
+export const getLocationPagesByServiceSlugs = async (
+  serviceSlugs: string[],
+): Promise<LocationPageNearbySuburbRef[]> => {
+  try {
+    if (serviceSlugs.length === 0) {
+      return [];
+    }
+
+    const result = await sanityClient.fetch(locationPagesByServiceSlugsQuery, { serviceSlugs });
+
+    const parsedLocations = (result as unknown[]).map((item) => LocationPageNearbySuburbRefSchema.parse(item));
+
+    return parsedLocations.map((location) => ({
+      id: location._id,
+      suburb: location.suburb,
+      slug: location.slug.current,
+    }));
+  } catch (error) {
+    console.error('Error in getLocationPagesByServiceSlugs:', error);
+    throw new Error('Failed to fetch location pages by service slugs');
   }
 };

--- a/packages/ses-next/src/lib/content/contentService.ts
+++ b/packages/ses-next/src/lib/content/contentService.ts
@@ -204,7 +204,7 @@ export const getLocationPagesByServiceSlugs = async (
 
     const result = await sanityClient.fetch(locationPagesByServiceSlugsQuery, { serviceSlugs });
 
-    const parsedLocations = (result as unknown[]).map((item) => LocationPageNearbySuburbRefSchema.parse(item));
+    const parsedLocations = LocationPageNearbySuburbRefSchema.array().parse(result);
 
     return parsedLocations.map((location) => ({
       id: location._id,

--- a/packages/ses-next/src/lib/content/queries.ts
+++ b/packages/ses-next/src/lib/content/queries.ts
@@ -234,6 +234,13 @@ export const locationPageBySlugQuery = `*[_type == "locationPage" && slug.curren
   seoDescription
 }`;
 
+export const locationPagesByServiceSlugsQuery = `*[_type == "locationPage" && count(services[@->slug.current in $serviceSlugs]) > 0] | order(suburb asc){
+  _id,
+  _type,
+  suburb,
+  slug
+}`;
+
 export const termsAndConditionsQuery = `*[_type == "terms-and-conditions"]{
   _id,
   _type,


### PR DESCRIPTION
## Summary
- add service page area links that resolve from `locationPage` references in Sanity (new query + content service mapper + UI section)
- render related location links on each service detail page so users can navigate to suburb-specific pages
- update the location pages PRD to make `locationPage` the source of truth for service areas and add homepage/menu rollout requirements

## Validation
- npm run format
- npm run lint
- npm run type:check
- npm run build
- npm run test:e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service pages now display nearby suburb/location links beneath service content with link cards.
  * Added a reusable Service Locations section to present location cards.

* **Documentation**
  * PRD updated: homepage location links moved under Services and a main-menu “Locations” entry is required.
  * Guidance updated so service-area lists must come from published location pages; migration checklist and acceptance criteria revised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->