### PR TITLE
Move Sanity studio hostname config to CLI config file

### DIFF
--- a/.github/workflows/deploy-sanity.yml
+++ b/.github/workflows/deploy-sanity.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm run build -w ses-content
 
       - name: Deploy Sanity Studio
-        run: npm run deploy -w ses-content -- --yes --studio-hostname ses
+        run: npm run deploy -w ses-content -- --yes
         env:
           SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
           NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ vars.SANITY_PROJECT_ID }}

--- a/packages/ses-content/sanity.cli.ts
+++ b/packages/ses-content/sanity.cli.ts
@@ -5,4 +5,5 @@ export default defineCliConfig({
     projectId: 'j7d3pd5g',
     dataset: 'production',
   },
+  studioHost: 'ses',
 })


### PR DESCRIPTION
## Summary
Moved the Sanity Studio hostname configuration from the deployment command-line arguments to the centralized CLI configuration file, improving configuration management and maintainability.

## Key Changes
- Removed `--studio-hostname ses` flag from the deploy command in the GitHub Actions workflow
- Added `studioHost: 'ses'` configuration to `sanity.cli.ts` to define the studio hostname at the source
- Simplified the deploy command by removing CLI-specific arguments in favor of configuration-driven setup

## Implementation Details
The studio hostname is now defined once in the Sanity CLI configuration file rather than being passed as a command-line argument during deployment. This approach provides a single source of truth for the configuration and makes the deployment workflow cleaner and more maintainable.

https://claude.ai/code/session_01DQRweq5BvKsTciqbnh2ECg