### PR TITLE
feat: add Locations to main nav and Services section homepage CTA

### DIFF
--- a/packages/ses-next/src/components/Navbar.tsx
+++ b/packages/ses-next/src/components/Navbar.tsx
@@ -18,6 +18,7 @@ const styles = {
 interface NavLinks {
   home: string;
   services: string;
+  locations: string;
   about: string;
   contact: string;
   faq: string;
@@ -27,6 +28,7 @@ interface NavLinks {
 const defaultNavLinks: NavLinks = {
   home: '/',
   services: '/services/',
+  locations: '/locations/',
   about: '/#about',
   contact: '/#contact',
   faq: '/faq',
@@ -219,6 +221,9 @@ function MenuItems({ links, contactPhone, onClick }: MenuItemsProps) {
       </MenuLinkItem>
       <MenuLinkItem href={links.services} onClick={onClick}>
         Services
+      </MenuLinkItem>
+      <MenuLinkItem href={links.locations} onClick={onClick}>
+        Locations
       </MenuLinkItem>
       <MenuLinkItem href={links.about} onClick={onClick}>
         About

--- a/packages/ses-next/src/components/Services.tsx
+++ b/packages/ses-next/src/components/Services.tsx
@@ -9,6 +9,7 @@ import type { IconMap } from '@/components/Icon/IconMap';
 import { type ServiceItem } from '@/types';
 
 const servicesHubPath = '/services/';
+const locationsPath = '/locations/';
 
 const ConditionalWrap = ({
   children,
@@ -89,6 +90,17 @@ export const Services = ({ className, blurbs, services }: ServicesProps) => {
               <p className="text-primary text-lg font-semibold group-hover:underline">
                 See all our electrical services →
               </p>
+            </div>
+          </div>
+          <div className="group border-primary relative w-full overflow-hidden rounded-lg border-2 border-dashed">
+            <Link href={locationsPath} className="absolute inset-0 z-10" prefetch={false}>
+              <span className="sr-only">View our service areas and locations</span>
+            </Link>
+            <div className="flex h-full min-h-[160px] flex-col items-center justify-center gap-3 p-6 text-center">
+              <div className="bg-primary/10 rounded-full p-3">
+                <Icon name="home" size="xl" className="text-primary" />
+              </div>
+              <p className="text-primary text-lg font-semibold group-hover:underline">View our service areas →</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- **Navbar**: Added a `Locations` link (`/locations/`) to the main menu between Services and About. Works in both the desktop nav and the mobile drawer.
- **Services section (homepage)**: Added a "View our service areas →" dashed-border CTA card below the services grid, linking to `/locations/`. Visually consistent with the existing "See all our electrical services →" card.

## Changes

- `packages/ses-next/src/components/Navbar.tsx` — added `locations` to `NavLinks` interface, `defaultNavLinks`, and `MenuItems`
- `packages/ses-next/src/components/Services.tsx` — added `locationsPath` constant and a second dashed CTA card linking to `/locations/`

## Checks

- ✅ `npm run format`
- ✅ `npm run lint`
- ✅ `npm run type:check`
- ✅ `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a "Locations" link to the main navigation menu for easy access to service areas and location information
* Introduced a new "Service Areas/Locations" card in the services grid, enabling users to discover location details directly from the services page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->