### PR TITLE
fix: add ISR revalidation and dynamicParams to blog pages

### DIFF
--- a/packages/ses-next/src/app/blog/[slug]/page.tsx
+++ b/packages/ses-next/src/app/blog/[slug]/page.tsx
@@ -25,6 +25,9 @@ const portableTextComponents = {
   },
 };
 
+export const revalidate = 3600;
+export const dynamicParams = true;
+
 export async function generateStaticParams() {
   const posts = await getBlogPosts();
   return posts.filter(({ slug }) => slug).map(({ slug }) => ({ slug }));

--- a/packages/ses-next/src/app/blog/page.tsx
+++ b/packages/ses-next/src/app/blog/page.tsx
@@ -7,6 +7,8 @@ import { getBlogPosts, getSiteSettings } from '@/lib/content/contentService';
 import { tagsWithCountFromBlogs } from '@/lib/blogUtils';
 import { safeJsonLd } from '@/lib/structuredData';
 
+export const revalidate = 3600;
+
 export const metadata: Metadata = {
   title: 'Blog | Storm Electrical Solutions',
   description: 'Electrical tips, guides, and news from the Storm Electrical Solutions team in Melbourne.',

--- a/packages/ses-next/src/app/blog/tag/[tag]/page.tsx
+++ b/packages/ses-next/src/app/blog/tag/[tag]/page.tsx
@@ -11,6 +11,9 @@ type BlogTagPageProps = {
   params: Promise<{ tag: string }>;
 };
 
+export const revalidate = 3600;
+export const dynamicParams = true;
+
 export async function generateStaticParams() {
   const posts = await getBlogPosts();
   const tagSet = new Set(posts.flatMap(({ tags }) => tags));


### PR DESCRIPTION
New blog posts published in Sanity after a build were invisible because
pages are fully static with no revalidation. Adding revalidate=3600 means
new posts appear within an hour, and dynamicParams=true allows slug pages
not generated at build time to be rendered on-demand.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
