### PR TITLE
chore: migrate GitHub issues to local ideas planning pipeline

### DIFF
--- a/docs/planning/ideas/2026-05-api-endpoint-for-on-demand-cache-revalidation.md
+++ b/docs/planning/ideas/2026-05-api-endpoint-for-on-demand-cache-revalidation.md
@@ -1,0 +1,52 @@
+---
+title: 'Add API endpoint for on-demand Next.js cache revalidation'
+status: captured
+priority: unset
+source: internal
+captured: '2026-05-06'
+domain: engineering
+prd: ''
+tags:
+  - nextjs
+  - cache
+  - sanity
+  - webhooks
+  - performance
+---
+
+# Add API endpoint for on-demand Next.js cache revalidation
+
+## Problem / Opportunity
+
+The site currently relies on a full deployment hook to pick up Sanity content changes, which means routine CMS publishes trigger a redeploy instead of targeted cache invalidation. This slows editorial updates and unnecessarily couples content changes to the deployment pipeline.
+
+## Context
+
+Replacing the deployment hook with a protected Next.js API route allows Sanity to call the endpoint after publish events and revalidate only the affected paths via `revalidatePath(...)`. The existing contact route at `packages/ses-next/src/app/api/contact/route.ts` shows the preferred Route Handler style. All Sanity reads currently flow through `packages/ses-next/src/lib/content/contentService.ts` with no existing cache tags. Tracked in GitHub issue #272.
+
+## Rough Scope
+
+- Add `POST /api/revalidate` route handler at `packages/ses-next/src/app/api/revalidate/route.ts` with shared-secret validation (`REVALIDATE_SECRET` env var)
+- Implement `_type` → `revalidatePath(...)` mapping covering all document types: `siteSettings`, `homepage`, `service`, `blog-post`, `faq`, `locationPage`, `terms-and-conditions`, `teamMember`, `training`, `showcase`
+- Add `revalidateSecret` to `packages/ses-next/src/lib/config.ts`
+- Configure the Sanity webhook to POST to the new endpoint instead of the deployment hook
+- Add route tests in `packages/ses-next/tests/routes.spec.ts` for unauthorized, invalid payload, and successful revalidation cases
+
+## Success Signal
+
+CMS content publishes update the live site within seconds via targeted cache revalidation, with no full redeploy required.
+
+## Open Questions
+
+- Should the webhook projection also send `slug.current` and `tags[]` to enable finer-grained path invalidation, or is `_type`-based path revalidation sufficient?
+- Should the existing deployment hook be kept as a fallback until the webhook is verified, or removed immediately?
+- Should sitemap revalidation (`/sitemap.xml`) be added for location pages (currently out of scope)?
+
+## References
+
+- `packages/ses-next/src/app/api/contact/route.ts`
+- `packages/ses-next/src/lib/content/contentService.ts`
+- `packages/ses-next/src/lib/config.ts`
+- `packages/ses-next/tests/routes.spec.ts`
+- `packages/ses-next/src/app/sitemap.ts`
+- GitHub issue #272

--- a/docs/planning/ideas/2026-05-configure-sanity-type-generation.md
+++ b/docs/planning/ideas/2026-05-configure-sanity-type-generation.md
@@ -1,0 +1,51 @@
+---
+title: 'Configure Sanity type generation'
+status: captured
+priority: unset
+source: internal
+captured: '2026-05-06'
+domain: engineering
+prd: ''
+tags:
+  - sanity
+  - typescript
+  - type-generation
+  - developer-experience
+---
+
+# Configure Sanity type generation
+
+## Problem / Opportunity
+
+`packages/ses-next/src/types.ts` contains hand-written TypeScript types for Sanity-backed content models that must be kept in sync manually. There is no Sanity type generation config, no generation script, and no generated types file — this creates duplication and drift risk as schemas evolve.
+
+## Context
+
+The Sanity workspace already exists at `packages/ses-content/` with `sanity.config.ts` and `sanity.cli.ts`, making it straightforward to add type generation. Currently all app code imports from `@/types` with manually defined schemas like `HomepageSchema`, `ServiceSchema`, `BlogPostSchema` etc., and uses `.parse(...)` on GROQ query results. Tracked in GitHub issue #369.
+
+## Rough Scope
+
+- Create `packages/ses-content/sanity-typegen.json` with generation config
+- Add a `typegen` script to `packages/ses-content/package.json` (`sanity schema extract` + `sanity typegen generate`)
+- Generate extracted schema JSON at `packages/ses-next/src/sanity/schema.json`
+- Generate TypeScript types at `packages/ses-next/src/sanity/sanity.types.ts`
+- Audit `packages/ses-next/src/types.ts` and replace duplicated Sanity schema types with generated ones; keep repo-specific types (forms, email payloads, mapped frontend types)
+
+## Success Signal
+
+Running `pnpm typegen -w ses-content` generates schema-driven types and the repo no longer hand-maintains duplicate Sanity document type definitions.
+
+## Open Questions
+
+- Should generated files be committed to the repo or regenerated in CI/local workflows?
+- Should GROQ query result type generation be tackled here or as a separate follow-up?
+- Which runtime Zod validations should be kept even after generated types are in place?
+
+## References
+
+- `packages/ses-next/src/types.ts`
+- `packages/ses-content/sanity.config.ts`
+- `packages/ses-content/sanity.cli.ts`
+- `packages/ses-next/src/lib/content/contentService.ts`
+- `packages/ses-next/src/lib/content/queries.ts`
+- GitHub issue #369

--- a/docs/planning/ideas/2026-05-finish-site-settings-cleanup-and-remove-homepage-overlap.md
+++ b/docs/planning/ideas/2026-05-finish-site-settings-cleanup-and-remove-homepage-overlap.md
@@ -1,0 +1,51 @@
+---
+title: 'Finish siteSettings cleanup and remove homepage overlap'
+status: captured
+priority: unset
+source: internal
+captured: '2026-05-06'
+domain: engineering
+prd: ''
+tags:
+  - sanity
+  - cms
+  - site-settings
+  - homepage
+  - refactor
+---
+
+# Finish siteSettings cleanup and remove homepage overlap
+
+## Problem / Opportunity
+
+The `siteSettings` singleton schema is already in place, but `homepage` still owns a duplicate `contact.phone` field that overlaps with `siteSettings.phone`. This split source of truth means phone updates must be made in two places and the data flow is inconsistent across components.
+
+## Context
+
+Most of the original siteSettings refactor is already implemented — the schema exists, Studio is configured, and `getSiteSettings()` is already consumed in `layout.tsx` for the navbar phone. The remaining gap is that `homepage.contact.phone` still exists alongside `siteSettings.phone`, and `Contact.tsx` still reads phone from the homepage mapper rather than from site settings. Tracked in GitHub issue #368.
+
+## Rough Scope
+
+- Remove `contact.phone` from `packages/ses-content/schemas/homepage.ts`
+- Update the homepage GROQ query in `packages/ses-next/src/lib/content/queries.ts` to drop the phone field
+- Update Zod/manual types in `packages/ses-next/src/types.ts` to remove the duplicate phone field
+- Update the homepage mapper in `packages/ses-next/src/lib/content/mappers.ts`
+- Update `packages/ses-next/src/components/Contact.tsx` to source phone from `siteSettings` instead of homepage content
+
+## Success Signal
+
+A single `siteSettings.phone` value drives all phone display on the site with no duplicate field in the homepage schema.
+
+## Open Questions
+
+- Should homepage-specific contact copy (`blurbs`, `callBack`) remain in the homepage schema or also migrate to siteSettings?
+- Are there other fields beyond `phone` still duplicated between `homepage` and `siteSettings`?
+
+## References
+
+- `packages/ses-content/schemas/homepage.ts`
+- `packages/ses-content/schemas/siteSettings.ts`
+- `packages/ses-next/src/lib/content/queries.ts`
+- `packages/ses-next/src/lib/content/mappers.ts`
+- `packages/ses-next/src/components/Contact.tsx`
+- GitHub issue #368

--- a/docs/planning/ideas/2026-05-migrate-sanity-content-layer-to-new-patterns.md
+++ b/docs/planning/ideas/2026-05-migrate-sanity-content-layer-to-new-patterns.md
@@ -1,0 +1,46 @@
+---
+title: 'Migrate Sanity content layer to new patterns'
+status: captured
+priority: unset
+source: internal
+captured: '2026-05-06'
+domain: engineering
+prd: ''
+tags:
+  - sanity
+  - refactor
+  - typescript
+  - content-layer
+---
+
+# Migrate Sanity content layer to new patterns
+
+## Problem / Opportunity
+
+The app still uses raw `fetch()` calls and manually maintained TypeScript types for Sanity data instead of the Sanity client, service layer, and generated types. This creates duplication, makes queries harder to maintain, and misses type safety improvements available through the modern Sanity SDK patterns.
+
+## Context
+
+`packages/ses-next/src/lib/content/contentApi.ts` uses raw `fetch()` with generic `*[]` GROQ queries instead of the Sanity client. `packages/ses-next/src/types.ts` contains manual Sanity document type definitions that overlap with what can be generated. This refactor depends on the type generation (#369) and domain service split (#370) being complete. Tracked in GitHub issue #371.
+
+## Rough Scope
+
+- Refactor `packages/ses-next/src/lib/content/contentApi.ts` to replace `fetch()` with `client.fetch(...)` using specific GROQ projections
+- Update `packages/ses-next/src/lib/content/contentService.ts` to use the new domain service layer functions
+- Refactor `packages/ses-next/src/types.ts` to remove manual Sanity document schema types, import from generated `sanity.types.ts`, and retain only business logic types (forms, email payloads, mapped frontend types like `ServiceItem`, `BlogPost`, etc.)
+
+## Success Signal
+
+No raw `fetch()` calls to the Sanity API remain; all queries go through the typed Sanity client; generated types replace hand-maintained schema definitions.
+
+## Open Questions
+
+- Should the caching strategy in `contentService.ts` change as part of this migration, or be addressed separately?
+- How should runtime Zod validation be handled once types are generated — keep validation, drop it, or replace with narrower guards?
+
+## References
+
+- `packages/ses-next/src/lib/content/contentApi.ts`
+- `packages/ses-next/src/lib/content/contentService.ts`
+- `packages/ses-next/src/types.ts`
+- GitHub issue #371 (depends on #369 and #370)

--- a/docs/planning/ideas/2026-05-split-content-service-into-domain-sanity-services.md
+++ b/docs/planning/ideas/2026-05-split-content-service-into-domain-sanity-services.md
@@ -1,0 +1,47 @@
+---
+title: 'Split contentService into domain-specific Sanity services'
+status: captured
+priority: unset
+source: internal
+captured: '2026-05-06'
+domain: engineering
+prd: ''
+tags:
+  - sanity
+  - architecture
+  - refactor
+  - content-layer
+---
+
+# Split contentService into domain-specific Sanity services
+
+## Problem / Opportunity
+
+All Sanity fetching logic lives in a single `contentService.ts` file, making it hard to maintain, test, and evolve individual content domains independently. The file owns the shared client setup plus homepage, services, blog, FAQ, locations, and terms fetching in one place.
+
+## Context
+
+`packages/ses-next/src/lib/content/contentService.ts` currently contains ~10 fetch functions spanning every content domain. The Sanity client, GROQ queries, and mappers already exist as separate files, so the structural split is straightforward without changing runtime behaviour. Tracked in GitHub issue #370.
+
+## Rough Scope
+
+- Extract the shared Sanity client into `packages/ses-next/src/lib/content/client.ts`
+- Create domain-specific service modules under `packages/ses-next/src/lib/content/services/`: `siteSettingsService.ts`, `homepageService.ts`, `serviceCatalogService.ts`, `blogService.ts`, `locationService.ts`, `faqService.ts`, `termsService.ts`
+- Keep a barrel/re-export in `contentService.ts` or `index.ts` during the refactor to minimise import churn across pages
+- Verify all existing pages/layouts still build and resolve imports correctly after the split
+
+## Success Signal
+
+Each content domain has its own focused service module, and `contentService.ts` is no longer a monolithic catch-all — the app behaviour is unchanged.
+
+## Open Questions
+
+- Should the barrel file be temporary (removed once all imports are updated) or kept permanently as a stable public API?
+- Should this adopt generated Sanity types (#369) simultaneously, or treat that as follow-up work?
+
+## References
+
+- `packages/ses-next/src/lib/content/contentService.ts`
+- `packages/ses-next/src/lib/content/queries.ts`
+- `packages/ses-next/src/lib/content/mappers.ts`
+- GitHub issue #370

--- a/docs/planning/ideas/_index.md
+++ b/docs/planning/ideas/_index.md
@@ -1,5 +1,5 @@
 ---
-updated: '2026-05-05'
+updated: '2026-05-06'
 ---
 
 # Ideas Pipeline
@@ -8,27 +8,32 @@ updated: '2026-05-05'
 
 | Status     | Count  |
 | ---------- | ------ |
-| Captured   | 10     |
+| Captured   | 15     |
 | Evaluating | 0      |
 | Accepted   | 0      |
 | Rejected   | 0      |
 | Deferred   | 0      |
-| **Total**  | **10** |
+| **Total**  | **15** |
 
 ## Ideas
 
-| File                                                                                                                                   | Title                                                                       | Status   | Priority | Domain         | Captured   | PRD |
-| -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | -------- | -------- | -------------- | ---------- | --- |
-| [2026-04-enhance-ci-pipeline-format-and-lint-checks.md](./2026-04-enhance-ci-pipeline-format-and-lint-checks.md)                       | Enhance CI pipeline checks for formatting and linting                       | captured | unset    | infrastructure | 2026-04-14 | —   |
-| [2026-04-global-contact-modal-from-navigation.md](./2026-04-global-contact-modal-from-navigation.md)                                   | Create a global contact modal accessible from site navigation               | captured | unset    | design         | 2026-04-14 | —   |
-| [2026-04-implement-dark-theme.md](./2026-04-implement-dark-theme.md)                                                                   | Implement a dark theme across the website                                   | captured | unset    | design         | 2026-04-14 | —   |
-| [2026-04-improve-ga-conversion-tracking-contact-and-menu-phone.md](./2026-04-improve-ga-conversion-tracking-contact-and-menu-phone.md) | Improve GA conversion tracking for contact form and menu phone clicks       | captured | unset    | seo            | 2026-04-14 | —   |
-| [2026-04-improve-theme-system-usage-tailwind-daisyui.md](./2026-04-improve-theme-system-usage-tailwind-daisyui.md)                     | Improve website theming by properly using Tailwind and DaisyUI theme system | captured | unset    | design         | 2026-04-14 | —   |
-| [2026-04-migrate-icons-to-better-icons-for-consistency.md](./2026-04-migrate-icons-to-better-icons-for-consistency.md)                 | Migrate icon system to Better Icons for consistency                         | captured | unset    | design         | 2026-04-14 | —   |
-| [2026-04-redesign-services-hub-layout.md](./2026-04-redesign-services-hub-layout.md)                                                   | Redesign services hub layout to be narrower and visually distinct           | captured | unset    | design         | 2026-04-14 | —   |
-| [2026-04-remove-hardcoded-business-content.md](./2026-04-remove-hardcoded-business-content.md)                                         | Remove hardcoded business content from website pages                        | captured | unset    | engineering    | 2026-04-14 | —   |
-| [2026-04-remove-typescript-casts-and-unsafe-patterns.md](./2026-04-remove-typescript-casts-and-unsafe-patterns.md)                     | Remove TypeScript casts and unsafe patterns across the codebase             | captured | unset    | engineering    | 2026-04-14 | —   |
-| [2026-04-reusable-page-layout-system.md](./2026-04-reusable-page-layout-system.md)                                                     | Create reusable page layouts for consistent implementation                  | captured | unset    | engineering    | 2026-04-14 | —   |
+| File                                                                                                                                                         | Title                                                                       | Status   | Priority | Domain         | Captured   | PRD |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- | -------- | -------- | -------------- | ---------- | --- |
+| [2026-04-enhance-ci-pipeline-format-and-lint-checks.md](./2026-04-enhance-ci-pipeline-format-and-lint-checks.md)                                             | Enhance CI pipeline checks for formatting and linting                       | captured | unset    | infrastructure | 2026-04-14 | —   |
+| [2026-04-global-contact-modal-from-navigation.md](./2026-04-global-contact-modal-from-navigation.md)                                                         | Create a global contact modal accessible from site navigation               | captured | unset    | design         | 2026-04-14 | —   |
+| [2026-04-implement-dark-theme.md](./2026-04-implement-dark-theme.md)                                                                                         | Implement a dark theme across the website                                   | captured | unset    | design         | 2026-04-14 | —   |
+| [2026-04-improve-ga-conversion-tracking-contact-and-menu-phone.md](./2026-04-improve-ga-conversion-tracking-contact-and-menu-phone.md)                       | Improve GA conversion tracking for contact form and menu phone clicks       | captured | unset    | seo            | 2026-04-14 | —   |
+| [2026-04-improve-theme-system-usage-tailwind-daisyui.md](./2026-04-improve-theme-system-usage-tailwind-daisyui.md)                                           | Improve website theming by properly using Tailwind and DaisyUI theme system | captured | unset    | design         | 2026-04-14 | —   |
+| [2026-04-migrate-icons-to-better-icons-for-consistency.md](./2026-04-migrate-icons-to-better-icons-for-consistency.md)                                       | Migrate icon system to Better Icons for consistency                         | captured | unset    | design         | 2026-04-14 | —   |
+| [2026-04-redesign-services-hub-layout.md](./2026-04-redesign-services-hub-layout.md)                                                                         | Redesign services hub layout to be narrower and visually distinct           | captured | unset    | design         | 2026-04-14 | —   |
+| [2026-04-remove-hardcoded-business-content.md](./2026-04-remove-hardcoded-business-content.md)                                                               | Remove hardcoded business content from website pages                        | captured | unset    | engineering    | 2026-04-14 | —   |
+| [2026-04-remove-typescript-casts-and-unsafe-patterns.md](./2026-04-remove-typescript-casts-and-unsafe-patterns.md)                                           | Remove TypeScript casts and unsafe patterns across the codebase             | captured | unset    | engineering    | 2026-04-14 | —   |
+| [2026-04-reusable-page-layout-system.md](./2026-04-reusable-page-layout-system.md)                                                                           | Create reusable page layouts for consistent implementation                  | captured | unset    | engineering    | 2026-04-14 | —   |
+| [2026-05-finish-site-settings-cleanup-and-remove-homepage-overlap.md](./2026-05-finish-site-settings-cleanup-and-remove-homepage-overlap.md)                 | Finish siteSettings cleanup and remove homepage overlap                     | captured | unset    | engineering    | 2026-05-06 | —   |
+| [2026-05-configure-sanity-type-generation.md](./2026-05-configure-sanity-type-generation.md)                                                                 | Configure Sanity type generation                                            | captured | unset    | engineering    | 2026-05-06 | —   |
+| [2026-05-split-content-service-into-domain-sanity-services.md](./2026-05-split-content-service-into-domain-sanity-services.md)                               | Split contentService into domain-specific Sanity services                   | captured | unset    | engineering    | 2026-05-06 | —   |
+| [2026-05-migrate-sanity-content-layer-to-new-patterns.md](./2026-05-migrate-sanity-content-layer-to-new-patterns.md)                                         | Migrate Sanity content layer to new patterns                                | captured | unset    | engineering    | 2026-05-06 | —   |
+| [2026-05-api-endpoint-for-on-demand-cache-revalidation.md](./2026-05-api-endpoint-for-on-demand-cache-revalidation.md)                                       | Add API endpoint for on-demand Next.js cache revalidation                   | captured | unset    | engineering    | 2026-05-06 | —   |
 
 ## Action Required
 


### PR DESCRIPTION
## Summary

- Captured 5 GitHub issues as idea files under `docs/planning/ideas/` so all work is tracked and prioritised in one location
- Updated `docs/planning/ideas/_index.md` to reflect 15 total captured ideas
- Closed GitHub issues #272, #368, #369, #370, #371 with a reference to the new idea files

## Ideas added

| File | Source issue |
|---|---|
| `2026-05-finish-site-settings-cleanup-and-remove-homepage-overlap.md` | #368 |
| `2026-05-configure-sanity-type-generation.md` | #369 |
| `2026-05-split-content-service-into-domain-sanity-services.md` | #370 |
| `2026-05-migrate-sanity-content-layer-to-new-patterns.md` | #371 |
| `2026-05-api-endpoint-for-on-demand-cache-revalidation.md` | #272 |

## Test plan

- [ ] No code changes — docs only, no tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added planning documentation outlining proposed engineering initiatives and infrastructure improvements for future development cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->