### PR TITLE
deps(config): reduce renovate memory usage

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "ignorePaths": ["**/node_modules/**", "**/.next/**"],
   "extends": [
     ":prHourlyLimit4",
     ":rebaseStalePrs",
@@ -27,6 +28,7 @@
       "Change": "All locks refreshed"
     }
   },
+  "dependencyDashboardOSVVulnerabilitySummary": "none",
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,
   "semanticCommitScope": "",


### PR DESCRIPTION
## Summary

Reduces Renovate's memory footprint to avoid OOM (kernel out of memory) errors seen in the Mend.io dashboard.

## Changes

- **`ignorePaths`** — explicitly ignore `**/node_modules/**` and `**/.next/**` build output so Renovate doesn't scan Next.js build artifacts
- **`dependencyDashboardOSVVulnerabilitySummary: "none"`** — disables OSV vulnerability lookups on the dashboard (one network call + memory allocation per package, 74 deps)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to exclude certain directories from processing, improving efficiency.
  * Modified vulnerability dashboard settings to simplify how vulnerability summaries are displayed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dejanvasic85/ses-next/pull/547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->