### PR TITLE
fix: renovate and pnpm should have the min release age aligned now

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,13 +6,3 @@ allowBuilds:
   puppeteer: true
   sharp: true
   unrs-resolver: true
-minimumReleaseAgeExclude:
-  - '@sanity/diff@5.28.0'
-  - '@sanity/mutator@5.28.0'
-  - '@sanity/schema@5.28.0'
-  - '@sanity/types@5.28.0'
-  - '@sanity/util@5.28.0'
-  - '@sanity/vision@5.28.0'
-  - groq@5.28.0
-  - next-sanity@13.0.7
-  - sanity@5.28.0

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,7 @@
     "schedule:earlyMondays"
   ],
   "automerge": true,
+  "minimumReleaseAge": "1 day",
   "commitMessageAction": "",
   "labels": ["dependencies"],
   "lockFileMaintenance": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified workspace configuration and updated dependency management settings to enforce a one-day minimum age requirement before applying dependency updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dejanvasic85/ses-next/pull/549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->