### PR TITLE
docs: July 2026 SEO scorecard + electrical-testing cluster uplift

### DIFF
--- a/docs/planning/plans/011-on-page-ranking-uplift/plan.md
+++ b/docs/planning/plans/011-on-page-ranking-uplift/plan.md
@@ -3,7 +3,7 @@ title: 'On-Page Ranking Uplift: Execution Plan'
 number: '011'
 status: in-progress
 created: '2026-06-27'
-updated: '2026-06-28T12:00:00'
+updated: '2026-07-20T00:00:00'
 owner: ''
 idea: '2026-06-on-page-ranking-uplift-near-miss-pages.md'
 started: '2026-06-28'
@@ -219,6 +219,70 @@ problem.
 
 ---
 
+## Phase 4 — Fix & rescue the electrical-testing cluster (Month 3 / August 2026)
+
+**Driven by the July 2026 scorecard.** The testing cluster is the biggest untapped demand on the site
+and it _regressed_ this month, so it is now the top priority. Diagnosis from live Sanity audit
+(2026-07-20):
+
+- `/services/electrical-testing` (`_id` `44c760a2-8311-44af-b2c8-5a3ffa1e766f`): **2,156 impr, 0 clicks,
+  pos 49.** Root cause found — its `seoDescription` field is **empty**, so the meta description falls
+  back to the stale `description`: _"Residential Tenancy Act Reporting. Test and Tag. Emergency Light
+  Testing. "_ (fragment list, trailing space, no keyword sentence, no CTA). Phase 2 marked this done but
+  never populated `seoDescription`. This is the single clearest, cheapest fix on the site.
+- `/blog/comprehensive-guide-to-electrical-testing`: **2,993 impr, 7 clicks, pos 20.** Its title/meta
+  are already strong (verified live) — the guide's problem is **position/authority, not snippet**, so it
+  needs internal links + depth, not a rewrite.
+- Keywords: `electrical testing` 16.4 → 24.2 ▼, `electrical safety testing` 23.9 → 36.0 ▼.
+
+### Task 4.1 — Populate the service page `seoDescription` (the actual fix) ✅ DONE 2026-07-20
+
+**File changed:** Sanity `service` document `44c760a2-8311-44af-b2c8-5a3ffa1e766f`
+(`electrical-testing`) — `seoDescription` set and **published live** (verified 159 chars):
+
+> Licensed electrical testing & safety inspections across Melbourne — test & tag, RCD & switchboard
+> testing, tenancy compliance. 5.0★, REC 24794. Call SES today.
+
+`seoTitle` left as-is ("Electrical Testing & Safety Inspections Melbourne | SES" — already strong).
+The stale `description` fragment no longer drives the meta description.
+
+**Verification:** ✅ field live in Sanity `published` perspective. Pending: meta reflects it on the live
+site after next ISR revalidation (daily); `electrical testing` / `electrical safety testing` position
+recovery + first clicks to be confirmed in the **August 20 scorecard**.
+
+### Task 4.2 — Pass authority to the guide (position, not snippet) ✅ DONE 2026-07-20
+
+**Audit finding:** two of the three intended sub-steps were **already live** from earlier work —
+(a) the guide → service link (`link-electrical-testing-service` → `/services/electrical-testing`) was
+already present, and (b) the guide already contains depth sections for `electrical safety testing` and
+`switchboard testing` (the `new-safety-*` / `new-switchboard-*` blocks). The only missing half was the
+**reverse link**.
+
+**File changed & published:** `electrical-testing` service `content` — appended a paragraph linking to
+the guide (`/blog/comprehensive-guide-to-electrical-testing`). The link is now **bidirectional**.
+Verified live in Sanity `published`.
+
+**Verification:** ✅ link live. Guide position + sub-query coverage to confirm in the August scorecard.
+
+### Task 4.3 — Cross-link from the now-ranking commercial pages ✅ DONE 2026-07-20
+
+**File changed & published:** `/services/commercial-electrician` `content` — the existing "Compliance
+testing and tagging" paragraph (`ce-p-4`) now links its "electrical testing and safety inspection"
+phrase to `/services/electrical-testing`, passing authority from a page that reached page 1 this month.
+Verified live in Sanity `published`.
+
+> Note: the intended location-page cross-links (Altona commercial pages) were **not** added — the
+> commercial-electrician service page is the stronger, more topically-relevant source and was sufficient
+> for this month. Revisit location-page links next month if `/services/electrical-testing` hasn't moved.
+
+**Verification:** ✅ link live in Sanity. `/services/electrical-testing` position recovery to confirm in
+the August scorecard. (No code changed — content-only, so no build/e2e needed.)
+
+> **Scope guard:** this is a content-only month (Sanity edits, no code) and fits the 3–5 hr retainer.
+> Ship this week so it re-crawls in time for the **August 20** scorecard.
+
+---
+
 ## Sanity CMS Steps (summary)
 
 This plan is predominantly CMS content work. Per month:
@@ -226,8 +290,12 @@ This plan is predominantly CMS content work. Per month:
 - [x] Phase 1: edit `seoTitle`/`seoDescription`/`intro` on `electrician-altona-north`,
       `electrician-altona`, `electrician-seddon` (locationPage) and `mains-upgrades` (service). _(completed 2026-06-28)_
 - [x] Phase 1: add internal links concentrating equity on the above. _(already live via CMS-driven homepage serviceAreas — confirmed 2026-06-28)_
-- [x] Phase 2: edit the `comprehensive-guide-to-electrical-testing` blog post + `electrical-testing`
-      service; add bidirectional links. _(completed 2026-06-28)_
+- [~] Phase 2: edit the `comprehensive-guide-to-electrical-testing` blog post + `electrical-testing`
+  service; add bidirectional links. _(guide title/meta done 2026-06-28 and verified live; service
+  page `seoDescription` was missing — **now populated & published 2026-07-20, Task 4.1**.
+  Bidirectional internal links still outstanding — see Phase 4 Tasks 4.2/4.3.)_
+- [x] Phase 4 (August): Task 4.1 `seoDescription` ✅, Task 4.2 service→guide reverse link ✅ (guide→service + depth were already live), Task 4.3 commercial-electrician→testing cross-link ✅. All published
+      2026-07-20. Impact to be measured in the August scorecard.
 - [x] Phase 3: rewrite titles/meta on low-CTR page-1 pages identified from GSC. _(completed 2026-06-28 — /faq and /services hardcoded metadata updated in code)_
 
 All edits are non-destructive (Sanity document history retains prior versions) and take effect on the

--- a/docs/planning/plans/011-on-page-ranking-uplift/plan.md
+++ b/docs/planning/plans/011-on-page-ranking-uplift/plan.md
@@ -238,10 +238,10 @@ and it _regressed_ this month, so it is now the top priority. Diagnosis from liv
 ### Task 4.1 — Populate the service page `seoDescription` (the actual fix) ✅ DONE 2026-07-20
 
 **File changed:** Sanity `service` document `44c760a2-8311-44af-b2c8-5a3ffa1e766f`
-(`electrical-testing`) — `seoDescription` set and **published live** (verified 159 chars):
+(`electrical-testing`) — `seoDescription` set and **published live** (149 chars, within the ~155 limit):
 
-> Licensed electrical testing & safety inspections across Melbourne — test & tag, RCD & switchboard
-> testing, tenancy compliance. 5.0★, REC 24794. Call SES today.
+> Licensed electrical testing & safety inspections in Melbourne — test & tag, RCD & switchboard
+> testing, tenancy compliance. 5.0★, REC 24794. Call SES.
 
 `seoTitle` left as-is ("Electrical Testing & Safety Inspections Melbourne | SES" — already strong).
 The stale `description` fragment no longer drives the meta description.
@@ -290,10 +290,10 @@ This plan is predominantly CMS content work. Per month:
 - [x] Phase 1: edit `seoTitle`/`seoDescription`/`intro` on `electrician-altona-north`,
       `electrician-altona`, `electrician-seddon` (locationPage) and `mains-upgrades` (service). _(completed 2026-06-28)_
 - [x] Phase 1: add internal links concentrating equity on the above. _(already live via CMS-driven homepage serviceAreas — confirmed 2026-06-28)_
-- [~] Phase 2: edit the `comprehensive-guide-to-electrical-testing` blog post + `electrical-testing`
-  service; add bidirectional links. _(guide title/meta done 2026-06-28 and verified live; service
-  page `seoDescription` was missing — **now populated & published 2026-07-20, Task 4.1**.
-  Bidirectional internal links still outstanding — see Phase 4 Tasks 4.2/4.3.)_
+- [x] Phase 2: edit the `comprehensive-guide-to-electrical-testing` blog post + `electrical-testing`
+      service; add bidirectional links. _(guide title/meta + depth done 2026-06-28; the outstanding parts —
+      service `seoDescription` and the bidirectional links — were **superseded and completed by Phase 4**
+      (Tasks 4.1–4.3), all published 2026-07-20.)_
 - [x] Phase 4 (August): Task 4.1 `seoDescription` ✅, Task 4.2 service→guide reverse link ✅ (guide→service + depth were already live), Task 4.3 commercial-electrician→testing cross-link ✅. All published
       2026-07-20. Impact to be measured in the August scorecard.
 - [x] Phase 3: rewrite titles/meta on low-CTR page-1 pages identified from GSC. _(completed 2026-06-28 — /faq and /services hardcoded metadata updated in code)_

--- a/docs/seo-geo/scorecards/2026-07.md
+++ b/docs/seo-geo/scorecards/2026-07.md
@@ -16,11 +16,13 @@ content fixes shipped **7 June** (PR #557 "content for SEO improvements", "crawl
 page 1. The catch: overall CTR fell, because impressions grew faster than clicks on the still-buried
 high-demand terms.
 
-> **Attribution note:** no on-page content shipped in _July_ — the July commits were infrastructure
-> (Sanity TypeGen, content-service refactor, deps). July's ranking gains are attributable to the
-> **7 June** content work, which was live before this window opened. Takeaway: **we did no SEO content
-> this month, so the pipeline is empty** — if we ship nothing now, the August scorecard has nothing new
-> to show. Ship on-page edits this week and they should surface in the **August 20** report.
+> **Attribution note:** no on-page content shipped during the measurement window (June 22 – July 19) —
+> the commits in that window were infrastructure (Sanity TypeGen, content-service refactor, deps).
+> July's ranking gains are attributable to the **7 June** content work, which was live before this
+> window opened. Takeaway: **no SEO content landed in-window, so the pipeline was empty** — if we ship
+> nothing, the August scorecard has nothing new to show. (Fixes were in fact shipped **20 July**, just
+> after this window closed — see the testing-cluster work below; their impact lands in the August
+> report.)
 
 ## North star — leads (GA4)
 
@@ -85,16 +87,16 @@ August.
 
 ## Content performance — top pages (GSC)
 
-| Page                                               | Clicks | Impr. | Position  | Note                                                      |
-| -------------------------------------------------- | ------ | ----- | --------- | --------------------------------------------------------- |
-| `/` (home, organic)                                | 32     | 1,817 | 42.4      | Most clicks — brand + generic blend                       |
-| `/services/mains-upgrades`                         | 14     | 1,307 | **19.67** | Best service page; climbed from 23.9 ▲                    |
-| `/` (home, gmb utm)                                | 11     | 1,614 | 3.64      | Brand search — converting                                 |
-| `/blog/comprehensive-guide-to-electrical-testing`  | 7      | 2,993 | 19.69     | 2,993 impr, 7 clicks — still the biggest untapped page    |
-| `/blog/victoria-power-prices-falling-july-2026`    | 3      | 374   | **7.76**  | 🆕 New July post — page 1 already. Topical timing worked  |
-| `/blog/electrical-safety-testing-guide-…landlords` | 3      | 479   | 26.47     | Climbing (was 28.4)                                       |
-| `/services/commercial-electrician`                 | 1      | 2,618 | 46.71     | 2,618 impr at pos 47 — huge buried demand                 |
-| `/services/electrical-testing`                     | 0      | 2,156 | 49.47     | Still buried (was 56) — seoDescription + links fixed 20 Jul |
+| Page                                               | Clicks | Impr. | Position  | Note                                                                                    |
+| -------------------------------------------------- | ------ | ----- | --------- | --------------------------------------------------------------------------------------- |
+| `/` (home, organic)                                | 32     | 1,817 | 42.4      | Most clicks — brand + generic blend                                                     |
+| `/services/mains-upgrades`                         | 14     | 1,307 | **19.67** | Best service page; climbed from 23.9 ▲                                                  |
+| `/` (home, gmb utm)                                | 11     | 1,614 | 3.64      | Brand search — converting                                                               |
+| `/blog/comprehensive-guide-to-electrical-testing`  | 7      | 2,993 | 19.69     | 2,993 impr, 7 clicks — still the biggest untapped page                                  |
+| `/blog/victoria-power-prices-falling-july-2026`    | 3      | 374   | **7.76**  | 🆕 New July post — page 1 already. Topical timing worked                                |
+| `/blog/electrical-safety-testing-guide-…landlords` | 3      | 479   | 26.47     | Climbing (was 28.4)                                                                     |
+| `/services/commercial-electrician`                 | 1      | 2,618 | 46.71     | 2,618 impr at pos 47 — huge buried demand                                               |
+| `/services/electrical-testing`                     | 0      | 2,156 | 49.47     | Still buried (was 56). seoDescription + links fixed 20 Jul (post-window; impact in Aug) |
 
 Two content wins: **`mains-upgrades` climbed to pos 19.7** and the **new July post
 (`victoria-power-prices-falling`) landed on page 1 at 7.76** — proof that a timely, near-miss-adjacent

--- a/docs/seo-geo/scorecards/2026-07.md
+++ b/docs/seo-geo/scorecards/2026-07.md
@@ -1,0 +1,146 @@
+---
+month: '2026-07'
+report-date: '2026-07-20'
+range: '28-day (2026-06-22 → 2026-07-19)'
+prior: '2026-06'
+---
+
+# SEO Scorecard — July 2026
+
+_Source range: 28 days to 2026-07-19. Compared against June 2026 (the baseline). First diff
+scorecard — this is the one that tells us whether the retainer moved the needle._
+
+**Headline:** the June on-page work matured and the near-misses climbed onto page 1. The
+content fixes shipped **7 June** (PR #557 "content for SEO improvements", "crawled-but-not-indexed" fix,
+24/7-wording removal) had re-crawled and re-ranked by this window. Five of six near-misses reached
+page 1. The catch: overall CTR fell, because impressions grew faster than clicks on the still-buried
+high-demand terms.
+
+> **Attribution note:** no on-page content shipped in _July_ — the July commits were infrastructure
+> (Sanity TypeGen, content-service refactor, deps). July's ranking gains are attributable to the
+> **7 June** content work, which was live before this window opened. Takeaway: **we did no SEO content
+> this month, so the pipeline is empty** — if we ship nothing now, the August scorecard has nothing new
+> to show. Ship on-page edits this week and they should surface in the **August 20** report.
+
+## North star — leads (GA4)
+
+| Metric                  | This month | Prior (Jun) | Δ        | Note                                      |
+| ----------------------- | ---------- | ----------- | -------- | ----------------------------------------- |
+| `generate_lead` (form)  | 17         | 8           | ▲ +9     | Form submissions — more than doubled      |
+| `first_time_phone_call` | 23         | 26          | ▼ −3     | New callers, roughly flat                 |
+| `repeat_phone_call`     | 4          | 7           | ▼ −3     | Returning callers                         |
+| `form_start`            | 11         | 11          | =        | 11 started → 17 leads (multi-submit)      |
+| **Total lead actions**  | **~44**    | **~41**     | **▲ +3** | Leads holding, form conversion up sharply |
+
+Lead capture remains healthy end-to-end. The standout is **`generate_lead` 8 → 17** — form-driven
+enquiries more than doubled while phone calls softened slightly, so the mix shifted toward form leads.
+Still no instrumentation work needed.
+
+## Demand — Google Search Console
+
+| Metric            | This month | Prior (Jun) | Δ      | Note                                        |
+| ----------------- | ---------- | ----------- | ------ | ------------------------------------------- |
+| Total impressions | ~17,500    | ~15,700     | ▲ +11% | Demand still growing                        |
+| Total clicks      | ~32        | ~50         | ▼ −36% | Absolute clicks down — see note             |
+| Avg CTR           | **0.18%**  | 0.32%       | ▼      | Fell — impressions grew on unclicked terms  |
+| Avg position      | **~31.9**  | ~32         | ≈ flat | Overall flat; the movement is page-specific |
+
+**Reconciling the mixed signal:** overall CTR dropped and clicks fell in absolute terms, which looks
+bad in isolation — but the overall average hides the real story. Average position is dragged down by a
+long tail of high-impression terms still stuck on page 4–7 (`commercial electrician melbourne` 30,
+`electrical safety inspection` 52, `electrician port melbourne` 71). Those terms gained _impressions_
+(inflating the denominator) without gaining _clicks_, which mechanically lowers blended CTR. Meanwhile
+**the specific pages we optimised moved up sharply** (below). This is the expected signature of a
+targeted ranking campaign: the pages you work on climb before the site-wide average catches up.
+
+> Mobile tells the healthier story: **mobile CTR 0.96% at avg position 23.8** vs desktop 0.29% at 33.4.
+> Where we rank on page 1–2 (mobile), clicks follow.
+
+## Tracked keyword positions
+
+_The locked set from `tracked-keywords.md`. Positions from GSC Queries.csv. Lower is better._
+
+| Keyword                             | Impr. | Clicks | Position | Baseline (Jun) | Δ pos       |
+| ----------------------------------- | ----- | ------ | -------- | -------------- | ----------- |
+| commercial electrician altona       | 101   | 0      | **4.08** | 12.07          | ▲ +8.0 🎯🏆 |
+| electrician altona north            | 221   | 1      | **5.84** | 12.98          | ▲ +7.1 🎯🏆 |
+| commercial electrician altona north | 32    | 0      | **4.34** | 8.05           | ▲ +3.7 🏆   |
+| electrician seddon                  | 90    | 1      | **9.11** | 9.85           | ▲ +0.7 🏆   |
+| melbourne electrical blog           | 34    | 0      | **4.26** | 8.46           | ▲ +4.2 🏆   |
+| mains power upgrade melbourne       | 80    | 0      | 13.18    | 13.71          | ▲ +0.5      |
+| electrician altona                  | 465   | 1      | 15.68    | 19.72          | ▲ +4.0      |
+| electrical testing                  | 395   | 0      | 24.21    | 16.39          | ▼ −7.8 ⚠️   |
+| electrical safety testing           | 232   | 0      | 36.04    | 23.88          | ▼ −12.2 ⚠️  |
+| smoke alarm installation melbourne  | 39    | 0      | 32.21    | 46.50          | ▲ +14.3     |
+
+**Five of six near-misses graduated.** `commercial electrician altona` (4.08), `commercial electrician
+altona north` (4.34), `melbourne electrical blog` (4.26) and `electrician altona north` (5.84) are all
+**top-6 on page 1** — a big win for the western-suburb commercial/local pages we tuned. `electrician
+seddon` held page 1. Only clicks lag position now, which is the next problem (page-1 title/snippet CTR).
+
+**The one regression to own:** the **electrical-testing terms went backwards** — `electrical testing`
+16.4 → 24.2, `electrical safety testing` 23.9 → 36.0. We flagged rescuing the testing guide as priority
+#2 last month; the near-miss work took the oxygen and testing slipped. This is now the top priority for
+August.
+
+## Content performance — top pages (GSC)
+
+| Page                                               | Clicks | Impr. | Position  | Note                                                      |
+| -------------------------------------------------- | ------ | ----- | --------- | --------------------------------------------------------- |
+| `/` (home, organic)                                | 32     | 1,817 | 42.4      | Most clicks — brand + generic blend                       |
+| `/services/mains-upgrades`                         | 14     | 1,307 | **19.67** | Best service page; climbed from 23.9 ▲                    |
+| `/` (home, gmb utm)                                | 11     | 1,614 | 3.64      | Brand search — converting                                 |
+| `/blog/comprehensive-guide-to-electrical-testing`  | 7      | 2,993 | 19.69     | 2,993 impr, 7 clicks — still the biggest untapped page    |
+| `/blog/victoria-power-prices-falling-july-2026`    | 3      | 374   | **7.76**  | 🆕 New July post — page 1 already. Topical timing worked  |
+| `/blog/electrical-safety-testing-guide-…landlords` | 3      | 479   | 26.47     | Climbing (was 28.4)                                       |
+| `/services/commercial-electrician`                 | 1      | 2,618 | 46.71     | 2,618 impr at pos 47 — huge buried demand                 |
+| `/services/electrical-testing`                     | 0      | 2,156 | 49.47     | Still buried (was 56) — seoDescription + links fixed 20 Jul |
+
+Two content wins: **`mains-upgrades` climbed to pos 19.7** and the **new July post
+(`victoria-power-prices-falling`) landed on page 1 at 7.76** — proof that a timely, near-miss-adjacent
+post ranks fast. The electrical-testing guide is _still_ the single biggest opportunity (2,993 impr, 7
+clicks) and `/services/commercial-electrician` surfaced as a new one (2,618 impr, pos 47).
+
+## GEO — AI visibility (spot-check)
+
+- GA shows **2 `AI Assistant` sessions** this period (was 1) with strong engagement (152s avg,
+  8.5 events/session) — small but the trend is up and these visitors are highly engaged.
+- The domain-content-services + ranking-uplift infrastructure shipped this month (commits `ce97d03`,
+  `5d27ce7`) — structured content signals are now emitting; plausibly supporting the AI surfacing.
+
+## What moved & why
+
+- **The June 7 on-page work landed (the retainer's thesis, confirmed — with a lag).** Every targeted
+  western-suburb commercial/local page climbed; five of six reached page 1. The credit belongs to the
+  **7 June** content fixes (PR #557), which were live before this window opened — _not_ to any July
+  change (July shipped only infrastructure). This is the clearest evidence yet that on-page optimisation
+  of page-1-adjacent terms converts to real ranking gains.
+- **New post ranked page 1 fast** (`victoria-power-prices-falling` at 7.76) — a timely, locally-relevant
+  post outperformed the smoke-alarm instinct, again validating the near-miss-adjacent content bet.
+- **Form leads more than doubled** (`generate_lead` 8 → 17). Can't fully attribute to SEO (traffic mix
+  is still Direct-heavy: 547 Direct vs 136 Organic sessions), but Organic Search sessions grew and
+  engaged at 66% — organic visitors are quality.
+- **Blended CTR fell, and that's mostly a denominator artefact** — impressions grew on still-buried
+  high-demand terms. The pages we touched improved; the site-wide average lags.
+- **The miss:** electrical-testing terms slipped (priority #2 got deprioritised). Own it and fix it next.
+
+## Focus for next month (August 2026)
+
+Priority order — **now convert page-1 rankings into clicks, and rescue testing:**
+
+1. **Rescue the electrical-testing cluster (carried over, now urgent).** `/services/electrical-testing`
+   (2,156 impr, pos 49) and the comprehensive guide (2,993 impr, pos 20) are the two largest untapped
+   pages on the site and testing terms _regressed_ this month. Refresh titles/meta, cross-link the guide
+   ↔ service page, expand depth. This is the biggest click opportunity we have.
+2. **Win clicks on the new page-1 rankings.** `commercial electrician altona` (4.08) and friends rank on
+   page 1 but earn ~0 clicks — that's now a **title/snippet CTR problem**, not a position problem. Tune
+   meta titles/descriptions on those location pages to be more clickable.
+3. **Attack `/services/commercial-electrician`** — 2,618 impressions at pos 47 is huge buried demand
+   that surfaced this month. On-page optimisation + internal links from the altona commercial pages
+   (which now rank) to pass authority.
+4. **Populate `owner.accreditations` in Sanity** (still outstanding from June, 15 min) — credential
+   JSON-LD is deployed but empty.
+
+> The June→July arc: we proved on-page work moves near-misses onto page 1. August's job is to (a) turn
+> those page-1 positions into actual clicks, and (b) apply the same playbook to the testing cluster,
+> which is the largest demand pool we're still losing.


### PR DESCRIPTION
## Summary

First month-over-month SEO scorecard (July 2026) plus the on-page fixes it drove. **Five of six tracked near-miss keywords reached page 1** — attributable to the 7 June on-page work maturing, not to any July change (July shipped only infrastructure).

## The regression we own — and fixed

`electrical-testing` terms slipped this month. Live Sanity audit found the root cause: the electrical-testing **service page `seoDescription` was empty**, falling back to a stale fragment (*"Residential Tenancy Act Reporting. Test and Tag…"*). Plan 011 Phase 2 marked this done but never populated the field.

## Shipped live to Sanity (production) — verified

- **Task 4.1** — populate electrical-testing service `seoDescription`
- **Task 4.2** — add service → guide reverse link (bidirectional now complete; guide → service + depth were already live)
- **Task 4.3** — cross-link `commercial-electrician` → `electrical-testing` (passes authority from a page that just reached page 1)

Content-only (Sanity edits, not code) — no build/e2e impact. Impact to be measured in the August scorecard.

## Files

- `docs/seo-geo/scorecards/2026-07.md` — the scorecard (honest attribution: June work matured; July pipeline was empty)
- `docs/planning/plans/011-on-page-ranking-uplift/plan.md` — Phase 4 recorded; corrected the false Phase 2 checkbox

Raw CSVs deleted per the scorecard ritual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the July 2026 SEO scorecard with performance metrics, ranking insights, content highlights, and August priorities.
  * Added an August plan to improve click-through rates and strengthen electrical-testing content.
  * Updated the on-page ranking plan with Phase 4 tasks, completion statuses, and internal linking improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->