### PR TITLE
Remove remaining unsafe TypeScript casts and assertions

### DIFF
--- a/packages/ses-content/.eslintrc
+++ b/packages/ses-content/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": "@sanity/eslint-config-studio"
-}

--- a/packages/ses-content/eslint.config.mjs
+++ b/packages/ses-content/eslint.config.mjs
@@ -1,0 +1,20 @@
+import {defineConfig, globalIgnores} from 'eslint/config'
+import studio from '@sanity/eslint-config-studio'
+import typescript from 'typescript-eslint'
+
+const eslintConfig = defineConfig([
+  ...studio,
+  globalIgnores(['dist/**']),
+  {
+    files: ['**/*.ts?(x)'],
+    plugins: {
+      '@typescript-eslint': typescript.plugin,
+    },
+    rules: {
+      '@typescript-eslint/consistent-type-assertions': ['error', {assertionStyle: 'never'}],
+      '@typescript-eslint/no-non-null-assertion': 'error',
+    },
+  },
+])
+
+export default eslintConfig

--- a/packages/ses-content/package.json
+++ b/packages/ses-content/package.json
@@ -11,6 +11,8 @@
     "deploy": "sanity deploy",
     "deploy-graphql": "sanity graphql deploy",
     "deploy:schema": "sanity schema deploy",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "type:check": "tsc --noEmit",
     "typegen": "sanity schema extract --path ../../packages/ses-next/src/sanity/schema.json && sanity typegen generate"
   },
@@ -28,8 +30,11 @@
     "styled-components": "6.4.4"
   },
   "devDependencies": {
+    "@sanity/eslint-config-studio": "6.0.0",
+    "eslint": "9.39.5",
     "prettier": "3.9.6",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "typescript-eslint": "8.65.0"
   },
   "prettier": {
     "semi": false,

--- a/packages/ses-content/schemas/service.ts
+++ b/packages/ses-content/schemas/service.ts
@@ -1,4 +1,4 @@
-import {defineField, defineType} from 'sanity'
+import {defineField, defineType, type Reference} from 'sanity'
 
 import iconField from './iconField'
 
@@ -81,10 +81,10 @@ export default defineType({
       description:
         'If set, this service appears as a sub-service under the parent. Leave empty for top-level services.',
       validation: (Rule) =>
-        Rule.custom(async (value, context) => {
-          const ref = (value as {_ref?: string} | undefined)?._ref
+        Rule.custom<Reference>(async (value, context) => {
+          const ref = value?._ref
           if (!ref) return true
-          const docId = (context.document as {_id?: string})?._id
+          const docId = context.document?._id
           if (ref === docId) {
             return 'A service cannot be its own parent'
           }

--- a/packages/ses-next/eslint.config.mjs
+++ b/packages/ses-next/eslint.config.mjs
@@ -100,10 +100,8 @@ const eslintConfig = defineConfig([
       '@typescript-eslint': typescriptPlugin,
     },
     rules: {
-      '@typescript-eslint/consistent-type-assertions': [
-        'error',
-        { assertionStyle: 'as', objectLiteralTypeAssertions: 'never' },
-      ],
+      '@typescript-eslint/consistent-type-assertions': ['error', { assertionStyle: 'never' }],
+      '@typescript-eslint/no-non-null-assertion': 'error',
     },
   },
 ]);

--- a/packages/ses-next/src/app/api/revalidate/route.ts
+++ b/packages/ses-next/src/app/api/revalidate/route.ts
@@ -1,10 +1,11 @@
 import { revalidateTag } from 'next/cache';
+import { z } from 'zod';
 
 import { config } from '@/lib/config';
 
-type RevalidateBody = {
-  _type: string;
-};
+const RevalidateBodySchema = z.object({
+  _type: z.string(),
+});
 
 const allowedTypes = new Set([
   'siteSettings',
@@ -33,11 +34,12 @@ export async function POST(request: Request) {
     return Response.json({ message: 'Invalid request body' }, { status: 400 });
   }
 
-  const body = rawBody as RevalidateBody;
-  if (!body._type) {
+  const parsedBody = RevalidateBodySchema.safeParse(rawBody);
+  if (!parsedBody.success) {
     return Response.json({ message: 'Missing _type field' }, { status: 400 });
   }
 
+  const body = parsedBody.data;
   if (!allowedTypes.has(body._type)) {
     return Response.json({ message: 'Unknown document type' }, { status: 400 });
   }

--- a/packages/ses-next/src/app/services/[...slug]/page.tsx
+++ b/packages/ses-next/src/app/services/[...slug]/page.tsx
@@ -106,9 +106,12 @@ export default async function ServicePage({ params }: ServicePageProps) {
     notFound();
   }
 
-  const childServices = services.filter((s) => s.parentService?.slug === service!.slug);
-  const filteredBlogPosts = blogPosts.filter(({ tags }) => tags.includes(service!.slug));
-  const serviceSlugs = service.parentService ? [service.slug, service.parentService.slug] : [service.slug];
+  const currentService = service;
+  const childServices = services.filter((s) => s.parentService?.slug === currentService.slug);
+  const filteredBlogPosts = blogPosts.filter(({ tags }) => tags.includes(currentService.slug));
+  const serviceSlugs = currentService.parentService
+    ? [currentService.slug, currentService.parentService.slug]
+    : [currentService.slug];
   let locationPages: LocationPageNearbySuburbRef[] = [];
 
   try {

--- a/packages/ses-next/src/components/Services.tsx
+++ b/packages/ses-next/src/components/Services.tsx
@@ -5,7 +5,6 @@ import { Container } from '@/components/Container';
 import { SanityImage } from '@/components/SanityImage';
 import { Heading } from '@/components/Heading';
 import { Icon } from '@/components/Icon/Icon';
-import type { IconMap } from '@/components/Icon/IconMap';
 import { type ServiceItem } from '@/types';
 
 const servicesHubPath = '/services/';
@@ -52,7 +51,7 @@ export const Services = ({ className, blurbs, services }: ServicesProps) => {
                   <div className="space-y-2">
                     <div className="flex items-center gap-3">
                       <div className="text-primary-foreground bg-primary rounded-full p-2">
-                        <Icon name={icon as keyof typeof IconMap} size="xl" className="text-primary-content" />
+                        <Icon name={icon} size="xl" className="text-primary-content" />
                       </div>
                       <h3 className="border-primary border-b-2 text-lg font-semibold">
                         <ConditionalWrap

--- a/packages/ses-next/src/lib/mailService.ts
+++ b/packages/ses-next/src/lib/mailService.ts
@@ -67,9 +67,8 @@ export async function send({ data, template, to = config.emailTo, companyName }:
   const { bodyTemplate, subjectTemplate } = emailTemplates[template];
 
   const interpolate = (tmpl: string) => {
-    const withData = (Object.keys(data) as (keyof EmailData)[]).reduce((prev, curr) => {
-      const value = data[curr];
-      return prev.replace(`{{${curr}}}`, String(value));
+    const withData = Object.entries(data).reduce((prev, [key, value]) => {
+      return prev.replace(`{{${key}}}`, String(value));
     }, tmpl);
     return companyName ? withData.replace('{{companyName}}', companyName) : withData;
   };

--- a/packages/ses-next/tests/routes.spec.ts
+++ b/packages/ses-next/tests/routes.spec.ts
@@ -84,7 +84,11 @@ test.describe('Blog Routes', () => {
     }
 
     const tagHref = await tagLink.getAttribute('href');
-    await page.goto(tagHref!);
+    if (!tagHref) {
+      test.skip();
+      return;
+    }
+    await page.goto(tagHref);
 
     await expect(page.locator('h1')).toBeVisible();
     const blogPost = page.locator('article, [data-testid="blog-post"]').first();

--- a/packages/ses-next/tests/theme.spec.ts
+++ b/packages/ses-next/tests/theme.spec.ts
@@ -32,10 +32,13 @@ function contrastRatio(foreground: Rgba, background: Rgba): number {
  * read back, which normalises all of them to sRGB.
  */
 async function readThemeSnapshot(page: Page, selectors: string[]): Promise<ThemeSnapshot> {
-  return page.evaluate((sels) => {
+  return page.evaluate<ThemeSnapshot, string[]>((sels) => {
     const canvas = document.createElement('canvas');
     canvas.width = canvas.height = 1;
-    const ctx = canvas.getContext('2d')!;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('2d canvas context unavailable');
+    }
 
     const resolveColor = (value: string): Rgba => {
       ctx.clearRect(0, 0, 1, 1);
@@ -77,7 +80,7 @@ async function readThemeSnapshot(page: Page, selectors: string[]): Promise<Theme
       baseContent: resolveColor(root.getPropertyValue('--color-base-content').trim()),
       measurements,
     };
-  }, selectors) as Promise<ThemeSnapshot>;
+  }, selectors);
 }
 
 /*
@@ -89,8 +92,10 @@ async function readThemeSnapshot(page: Page, selectors: string[]): Promise<Theme
  */
 function expectLegible(snapshot: ThemeSnapshot, selector: string) {
   const measured = snapshot.measurements[selector];
-  expect(measured, `no element matched ${selector}`).not.toBeNull();
-  const ratio = contrastRatio(measured!.color, measured!.background);
+  if (!measured) {
+    throw new Error(`no element matched ${selector}`);
+  }
+  const ratio = contrastRatio(measured.color, measured.background);
   expect(ratio, `${selector} contrast ratio`).toBeGreaterThanOrEqual(minimumBodyContrast);
 }
 
@@ -139,9 +144,11 @@ test.describe('Theme tokens', () => {
       // its wrapper, so prose's own body variable would never be exercised.
       await page.goto('/blog');
       const firstPost = await page.locator('a[href^="/blog/"]').first().getAttribute('href');
-      expect(firstPost, 'no blog posts to sample').toBeTruthy();
+      if (!firstPost) {
+        throw new Error('no blog posts to sample');
+      }
 
-      await page.goto(firstPost!);
+      await page.goto(firstPost);
       const snapshot = await readThemeSnapshot(page, ['.prose p']);
 
       expectLegible(snapshot, '.prose p');
@@ -165,7 +172,11 @@ test.describe('Theme tokens', () => {
           .trim()
           .replace(/^["']|["']$/g, '');
 
-      const headingStack = getComputedStyle(document.querySelector('h1')!).fontFamily;
+      const heading = document.querySelector('h1');
+      if (!heading) {
+        throw new Error('no h1 found');
+      }
+      const headingStack = getComputedStyle(heading).fontFamily;
       const bodyStack = getComputedStyle(document.body).fontFamily;
       const loaded = [...document.fonts].filter((face) => face.status === 'loaded').map((face) => face.family);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,12 +54,21 @@ importers:
         specifier: 6.4.4
         version: 6.4.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
+      '@sanity/eslint-config-studio':
+        specifier: 6.0.0
+        version: 6.0.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      eslint:
+        specifier: 9.39.5
+        version: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       prettier:
         specifier: 3.9.6
         version: 3.9.6
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      typescript-eslint:
+        specifier: 8.65.0
+        version: 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
 
   packages/ses-next:
     dependencies:
@@ -2293,6 +2302,12 @@ packages:
     resolution: {integrity: sha512-sXi3CaMLXkA2EWPfkCaL1fmVysh9a/IRueO/5/5rY2GCBXKR3j/BPb6p216U5I9Yn+t8Vn82W3htkDIRh83vsg==}
     engines: {node: '>=22.12'}
 
+  '@sanity/eslint-config-studio@6.0.0':
+    resolution: {integrity: sha512-IfIItATVN5QhlwA3mWGBnWIHpfnQSa1XuTL1BOIZdzkcg02AAWjHcU40Z9WrWWCll1yPbmmAWvmSU4PX9DsBTA==}
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      eslint: ^9.0.0
+
   '@sanity/eventsource@5.0.4':
     resolution: {integrity: sha512-NT6XrTJePJd7q1ZdTqB3NsTyNNOe9R2zMkg4Hlkqwb0LL6UmekVamAD46yjSJ+HbRyXAKLl1Rb65xZBdzC1f8Q==}
 
@@ -2808,8 +2823,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/eslint-plugin@8.65.0':
+    resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.65.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@8.60.1':
     resolution: {integrity: sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.65.0':
+    resolution: {integrity: sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -2821,12 +2851,28 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.65.0':
+    resolution: {integrity: sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.60.1':
     resolution: {integrity: sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.65.0':
+    resolution: {integrity: sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.60.1':
     resolution: {integrity: sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/tsconfig-utils@8.65.0':
+    resolution: {integrity: sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -2838,12 +2884,29 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/type-utils@8.65.0':
+    resolution: {integrity: sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@8.60.1':
     resolution: {integrity: sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.65.0':
+    resolution: {integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.60.1':
     resolution: {integrity: sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.65.0':
+    resolution: {integrity: sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -2855,8 +2918,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.65.0':
+    resolution: {integrity: sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.60.1':
     resolution: {integrity: sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.65.0':
+    resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@uiw/codemirror-extensions-basic-setup@4.25.11':
@@ -5993,6 +6067,13 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  typescript-eslint@8.65.0:
+    resolution: {integrity: sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -8847,6 +8928,17 @@ snapshots:
     dependencies:
       '@sanity/diff-match-patch': 3.2.0
 
+  '@sanity/eslint-config-studio@6.0.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
+    dependencies:
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      typescript-eslint: 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@sanity/eventsource@5.0.4':
     dependencies:
       '@types/event-source-polyfill': 1.0.5
@@ -9581,12 +9673,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/type-utils': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.60.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.60.1
       '@typescript-eslint/types': 8.60.1
       '@typescript-eslint/typescript-estree': 8.60.1(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.60.1
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3
@@ -9602,12 +9722,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.65.0(supports-color@8.1.1)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.65.0
+      debug: 4.4.3(supports-color@8.1.1)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.60.1':
     dependencies:
       '@typescript-eslint/types': 8.60.1
       '@typescript-eslint/visitor-keys': 8.60.1
 
+  '@typescript-eslint/scope-manager@8.65.0':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
+
   '@typescript-eslint/tsconfig-utils@8.60.1(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
@@ -9623,7 +9761,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.60.1': {}
+
+  '@typescript-eslint/types@8.65.0': {}
 
   '@typescript-eslint/typescript-estree@8.60.1(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
@@ -9631,6 +9783,21 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.60.1
       '@typescript-eslint/visitor-keys': 8.60.1
+      debug: 4.4.3(supports-color@8.1.1)
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.65.0(supports-color@8.1.1)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.65.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.5
@@ -9651,9 +9818,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@8.1.1)(typescript@6.0.3)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.60.1':
     dependencies:
       '@typescript-eslint/types': 8.60.1
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.65.0':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
       eslint-visitor-keys: 5.0.1
 
   '@uiw/codemirror-extensions-basic-setup@4.25.11(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.6)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)':
@@ -13073,6 +13256,17 @@ snapshots:
       '@typescript-eslint/parser': 8.60.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.60.1(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/utils': 8.60.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.65.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Replaces the last `as` casts and `!` non-null assertions in the app and Sanity schema packages with real runtime validation and type narrowing (zod-validated revalidate webhook body, Sanity's `Reference`/`ValidationContext` types in the service schema, `Object.entries` instead of a `keyof` cast in `mailService`, `const`-narrowing instead of `!` in the service page and two Playwright specs)
- Tightens `ses-next`'s `@typescript-eslint/consistent-type-assertions` to `assertionStyle: 'never'` and adds `no-non-null-assertion`, so any regression is caught in CI going forward
- Wires up an equivalent ESLint setup (`@sanity/eslint-config-studio` + the same two rules) for `ses-content`, which had no `lint` script at all before this — the schema fix would otherwise have no CI enforcement

Closes #639.

## Test plan
- [x] `pnpm format`
- [x] `pnpm lint` (both workspaces, zero errors)
- [x] `pnpm type:check`
- [x] `pnpm build`
- [x] `pnpm test:e2e` (33 passed, 1 skipped — pre-existing skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3VxH5rcpKnswAxXqH67zF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for revalidation requests, returning clearer errors for invalid payloads.
  * Strengthened service-page handling to avoid failures when service data is unavailable.
  * Improved email template variable replacement reliability.
  * Made automated checks handle missing links, elements, and browser resources more safely.

* **Chores**
  * Added standardized linting commands and stricter TypeScript checks across packages.
  * Improved validation typing for service relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->