### PR TITLE
chore: migrate from class-names to clsx

### DIFF
--- a/packages/ses-next/custom.d.ts
+++ b/packages/ses-next/custom.d.ts
@@ -1,6 +1,5 @@
 // Module declarations
 declare module 'ses-reviews';
-declare module 'class-names';
 
 interface Window {
   dataLayer: Record<string, unknown>[];

--- a/packages/ses-next/package.json
+++ b/packages/ses-next/package.json
@@ -23,7 +23,7 @@
     "@tailwindcss/postcss": "4.3.3",
     "@tailwindcss/typography": "0.5.20",
     "autoprefixer": "10.5.4",
-    "class-names": "1.0.0",
+    "clsx": "2.1.1",
     "daisyui": "5.7.7",
     "date-fns": "4.4.0",
     "eslint": "9.39.5",

--- a/packages/ses-next/src/components/ContactForm.tsx
+++ b/packages/ses-next/src/components/ContactForm.tsx
@@ -3,7 +3,7 @@
 import { Activity } from 'react';
 import { useCallback } from 'react';
 
-import classNames from 'class-names';
+import { clsx } from 'clsx';
 import { useForm } from 'react-hook-form';
 import { useGoogleReCaptcha } from 'react-google-recaptcha-v3';
 import { ContactFormData } from '@/types';
@@ -58,7 +58,7 @@ export function ContactForm({ loading, onSubmit }: ContactFormProps) {
           id="email"
           aria-invalid={!!emailError?.message}
           aria-describedby={!!emailError?.message ? 'emailErrorMessage' : undefined}
-          className={classNames('input input-bordered w-full', { 'input-error': emailError?.message })}
+          className={clsx('input input-bordered w-full', { 'input-error': emailError?.message })}
           {...register('email', {
             required: { value: true, message: 'Email is required' },
             pattern: {
@@ -85,7 +85,7 @@ export function ContactForm({ loading, onSubmit }: ContactFormProps) {
           id="fullName"
           aria-invalid={!!fullNameError?.message}
           aria-describedby={!!fullNameError?.message ? 'fullNameErrorMessage' : undefined}
-          className={classNames('input input-bordered w-full', { 'input-error': fullNameError?.message })}
+          className={clsx('input input-bordered w-full', { 'input-error': fullNameError?.message })}
           {...register('fullName')}
         />
         <Activity mode={fullNameError ? 'visible' : 'hidden'}>
@@ -105,7 +105,7 @@ export function ContactForm({ loading, onSubmit }: ContactFormProps) {
           maxLength={100}
           aria-invalid={!!phoneError?.message}
           aria-describedby={!!phoneError?.message ? 'phoneErrorMessage' : undefined}
-          className={classNames('input input-bordered w-full', { 'input-error': phoneError?.message })}
+          className={clsx('input input-bordered w-full', { 'input-error': phoneError?.message })}
           {...register('phone')}
         />
         <Activity mode={phoneError ? 'visible' : 'hidden'}>
@@ -125,7 +125,7 @@ export function ContactForm({ loading, onSubmit }: ContactFormProps) {
           maxLength={100}
           aria-invalid={!!addressError?.message}
           aria-describedby={!!addressError?.message ? 'addressErrorMessage' : undefined}
-          className={classNames('input input-bordered w-full', { 'input-error': addressError?.message })}
+          className={clsx('input input-bordered w-full', { 'input-error': addressError?.message })}
           {...register('address')}
         />
         <Activity mode={addressError ? 'visible' : 'hidden'}>
@@ -145,7 +145,7 @@ export function ContactForm({ loading, onSubmit }: ContactFormProps) {
           rows={4}
           aria-invalid={!!messageError?.message}
           aria-describedby={!!messageError?.message ? 'messageErrorMessage' : undefined}
-          className={classNames('textarea textarea-bordered w-full', { 'textarea-error': messageError?.message })}
+          className={clsx('textarea textarea-bordered w-full', { 'textarea-error': messageError?.message })}
           {...register('message', {
             required: { value: true, message: 'Message is required' },
           })}
@@ -159,7 +159,7 @@ export function ContactForm({ loading, onSubmit }: ContactFormProps) {
         </Activity>
       </fieldset>
 
-      <button className={classNames('btn btn-primary mt-8', { loading })} type="submit" id="submit">
+      <button className={clsx('btn btn-primary mt-8', { loading })} type="submit" id="submit">
         Submit
       </button>
     </form>

--- a/packages/ses-next/src/components/Heading.tsx
+++ b/packages/ses-next/src/components/Heading.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'class-names';
+import { clsx } from 'clsx';
 
 type HeadingAlign = 'center' | 'left';
 
@@ -27,7 +27,7 @@ export function Heading({ level, align = 'center', className, children }: Headin
   return React.createElement(
     `h${level}`,
     {
-      className: classNames(baseStyles, alignStyles[align], levelStyles[level], className),
+      className: clsx(baseStyles, alignStyles[align], levelStyles[level], className),
     },
     children,
   );

--- a/packages/ses-next/src/components/Icon/Icon.tsx
+++ b/packages/ses-next/src/components/Icon/Icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'class-names';
+import { clsx } from 'clsx';
 
 import { IconMap } from '@/components/Icon/IconMap';
 
@@ -24,5 +24,5 @@ interface IconProps {
 
 export function Icon({ className = '', name, size = 'md' }: IconProps) {
   const sizeClass = className.includes('h-') || className.includes('w-') ? '' : sizeClassMap[size];
-  return React.cloneElement(IconMap[name], { className: classNames(sizeClass, className) });
+  return React.cloneElement(IconMap[name], { className: clsx(sizeClass, className) });
 }

--- a/packages/ses-next/src/components/LinkButton.tsx
+++ b/packages/ses-next/src/components/LinkButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'class-names';
+import { clsx } from 'clsx';
 
 type LinkButtonVariant = 'primary' | 'glass' | 'ghost';
 
@@ -15,7 +15,7 @@ const variantStyles: Record<LinkButtonVariant, string> = {
 };
 
 export const LinkButton = ({ variant = 'primary', className, children, ...rest }: LinkButtonProps) => (
-  <a className={classNames('btn', variantStyles[variant], className)} {...rest}>
+  <a className={clsx('btn', variantStyles[variant], className)} {...rest}>
     {children}
   </a>
 );

--- a/packages/ses-next/src/components/Navbar/NavBrand.tsx
+++ b/packages/ses-next/src/components/Navbar/NavBrand.tsx
@@ -1,5 +1,5 @@
 import NextLink from 'next/link';
-import classNames from 'class-names';
+import { clsx } from 'clsx';
 
 import { Icon } from '@/components/Icon/Icon';
 import { homeHref } from '@/components/Navbar/navItems';
@@ -18,7 +18,7 @@ export function NavBrand({ title, className, onClick }: NavBrandProps) {
     <NextLink
       href={homeHref}
       onClick={onClick}
-      className={classNames('group flex min-w-0 items-center gap-2.5', focusStyles, className)}
+      className={clsx('group flex min-w-0 items-center gap-2.5', focusStyles, className)}
     >
       {/* The mark carries the logo's bolt gradient; both stops are theme tokens. */}
       <span className="from-secondary to-primary text-primary-content ring-primary-content/20 flex size-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br shadow-sm ring-1 transition-transform duration-300 ring-inset group-hover:-rotate-6">

--- a/packages/ses-next/src/components/Navbar/NavDrawer.tsx
+++ b/packages/ses-next/src/components/Navbar/NavDrawer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import classNames from 'class-names';
+import { clsx } from 'clsx';
 
 import { Icon } from '@/components/Icon/Icon';
 import { NavBrand } from '@/components/Navbar/NavBrand';
@@ -61,7 +61,7 @@ export function NavDrawer({ isOpen, pathname, title, contactPhone, licence, onCl
    */
   return (
     <div
-      className={classNames(
+      className={clsx(
         'fixed inset-0 z-50 flex justify-end transition-[visibility] duration-0 md:hidden',
         isOpen ? 'pointer-events-auto visible delay-0' : 'pointer-events-none invisible delay-300',
       )}
@@ -69,7 +69,7 @@ export function NavDrawer({ isOpen, pathname, title, contactPhone, licence, onCl
       <div
         onClick={onClose}
         aria-hidden="true"
-        className={classNames(
+        className={clsx(
           // eslint-disable-next-line no-restricted-syntax -- a scrim is an overlay, not a themed surface; raw black stays legible under either theme
           'absolute inset-0 bg-black/40 backdrop-blur-sm transition-opacity duration-300',
           isOpen ? 'opacity-100' : 'opacity-0',
@@ -83,7 +83,7 @@ export function NavDrawer({ isOpen, pathname, title, contactPhone, licence, onCl
         aria-label="Site menu"
         inert={!isOpen}
         onKeyDown={handleKeyDown}
-        className={classNames('relative', panelStyles, isOpen ? 'translate-x-0' : 'translate-x-full')}
+        className={clsx('relative', panelStyles, isOpen ? 'translate-x-0' : 'translate-x-full')}
       >
         <header className="border-base-300 flex h-16 shrink-0 items-center justify-between border-b pr-2 pl-4">
           <NavBrand title={title} onClick={onClose} />

--- a/packages/ses-next/src/components/Navbar/NavDrawerRow.tsx
+++ b/packages/ses-next/src/components/Navbar/NavDrawerRow.tsx
@@ -1,5 +1,5 @@
 import NextLink from 'next/link';
-import classNames from 'class-names';
+import { clsx } from 'clsx';
 
 import { Icon } from '@/components/Icon/Icon';
 import type { NavItem } from '@/components/Navbar/navItems';
@@ -21,10 +21,10 @@ export function NavDrawerRow({ item, isCurrent, onClick }: NavDrawerRowProps) {
       href={item.href}
       onClick={onClick}
       aria-current={isCurrent ? 'page' : undefined}
-      className={classNames(rowStyles, isCurrent ? 'bg-primary/10' : 'hover:bg-base-200 active:bg-base-200')}
+      className={clsx(rowStyles, isCurrent ? 'bg-primary/10' : 'hover:bg-base-200 active:bg-base-200')}
     >
       <span
-        className={classNames(
+        className={clsx(
           tileStyles,
           isCurrent
             ? 'bg-primary text-primary-content'
@@ -34,7 +34,7 @@ export function NavDrawerRow({ item, isCurrent, onClick }: NavDrawerRowProps) {
         <Icon name={item.icon} size="md" />
       </span>
       <span
-        className={classNames(
+        className={clsx(
           'font-display flex-1 text-lg font-medium tracking-tight',
           isCurrent ? 'text-primary' : 'text-base-content',
         )}
@@ -44,7 +44,7 @@ export function NavDrawerRow({ item, isCurrent, onClick }: NavDrawerRowProps) {
       <Icon
         name="chevron-right"
         size="sm"
-        className={classNames(
+        className={clsx(
           'transition-transform duration-200 group-hover:translate-x-0.5',
           isCurrent ? 'text-primary' : 'text-base-content/30',
         )}

--- a/packages/ses-next/src/components/Navbar/NavRail.tsx
+++ b/packages/ses-next/src/components/Navbar/NavRail.tsx
@@ -1,5 +1,5 @@
 import NextLink from 'next/link';
-import classNames from 'class-names';
+import { clsx } from 'clsx';
 
 import { isCurrentNavItem, railItems } from '@/components/Navbar/navItems';
 
@@ -23,7 +23,7 @@ export function NavRail({ pathname }: NavRailProps) {
             <NextLink
               href={item.href}
               aria-current={isCurrent ? 'page' : undefined}
-              className={classNames(linkStyles, isCurrent ? 'text-primary' : restingStyles)}
+              className={clsx(linkStyles, isCurrent ? 'text-primary' : restingStyles)}
             >
               {item.label}
             </NextLink>

--- a/packages/ses-next/src/components/Navbar/Navbar.tsx
+++ b/packages/ses-next/src/components/Navbar/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
-import classNames from 'class-names';
+import { clsx } from 'clsx';
 
 import { Container } from '@/components/Container';
 import { Icon } from '@/components/Icon/Icon';
@@ -70,7 +70,7 @@ export function Navbar({ contactPhone, title, licence }: NavbarProps) {
 
   return (
     <>
-      <nav aria-label="Main" className={classNames(navStyles, isScrolled && scrolledStyles)}>
+      <nav aria-label="Main" className={clsx(navStyles, isScrolled && scrolledStyles)}>
         <Container>
           <div className="flex h-16 w-full items-center justify-between gap-4">
             <NavBrand title={title} />
@@ -87,7 +87,7 @@ export function Navbar({ contactPhone, title, licence }: NavbarProps) {
                   </a>
                   <a
                     href={`tel:${contactPhone}`}
-                    className={classNames(iconButtonStyles, 'md:hidden')}
+                    className={clsx(iconButtonStyles, 'md:hidden')}
                     aria-label={`Call ${contactPhone}`}
                   >
                     <Icon name="phone" size="lg" />
@@ -99,7 +99,7 @@ export function Navbar({ contactPhone, title, licence }: NavbarProps) {
                 ref={menuButtonRef}
                 type="button"
                 onClick={() => setIsMenuOpen(true)}
-                className={classNames(iconButtonStyles, 'md:hidden')}
+                className={clsx(iconButtonStyles, 'md:hidden')}
                 aria-label="Open menu"
                 aria-expanded={isMenuOpen}
                 aria-haspopup="dialog"
@@ -113,7 +113,7 @@ export function Navbar({ contactPhone, title, licence }: NavbarProps) {
         {/* The bus bar doubles as the header's only divider — dim at rest, lit once you scroll. */}
         <span
           aria-hidden="true"
-          className={classNames(
+          className={clsx(
             'nav-busbar absolute inset-x-0 bottom-0 h-px transition-opacity duration-300',
             isScrolled ? 'opacity-100' : 'opacity-40',
           )}

--- a/packages/ses-next/src/components/PopSuccess.tsx
+++ b/packages/ses-next/src/components/PopSuccess.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'class-names';
+import { clsx } from 'clsx';
 
 import { Icon } from '@/components/Icon/Icon';
 
@@ -10,7 +10,7 @@ interface PopSuccessProps {
 export function PopSuccess({ children }: PopSuccessProps) {
   return (
     <div
-      className={classNames(
+      className={clsx(
         'motion-safe:animate-popin bg-success text-success-content mx-auto flex items-start justify-center gap-1 rounded-lg p-4 text-sm md:items-center md:text-base',
       )}
     >

--- a/packages/ses-next/src/components/Section.tsx
+++ b/packages/ses-next/src/components/Section.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'class-names';
+import { clsx } from 'clsx';
 
 type SectionTone = 'plain' | 'quiet';
 
@@ -22,7 +22,7 @@ const toneStyles: Record<SectionTone, string> = {
  */
 export function Section({ id, tone = 'plain', className, children }: SectionProps) {
   return (
-    <section id={id} className={classNames('py-16 md:py-24', id && 'scroll-mt-20', toneStyles[tone], className)}>
+    <section id={id} className={clsx('py-16 md:py-24', id && 'scroll-mt-20', toneStyles[tone], className)}>
       {children}
     </section>
   );

--- a/packages/ses-next/src/components/Testimonial.tsx
+++ b/packages/ses-next/src/components/Testimonial.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import classNames from 'class-names';
+import { clsx } from 'clsx';
 
 import { Icon } from '@/components/Icon/Icon';
 import { ConditionalWrap } from '@/components/ConditionalWrap';
@@ -77,7 +77,7 @@ export function Testimonial(testimonial: TestimonialProps) {
           </div>
           <Rating starRating={starRating} name={displayName} />
           <div>
-            <div ref={textRef} className={classNames('text-base-content/80 pr-4', { 'line-clamp-4': !showMore })}>
+            <div ref={textRef} className={clsx('text-base-content/80 pr-4', { 'line-clamp-4': !showMore })}>
               &ldquo;{comment}&rdquo;
             </div>
             {(isClamped || showMore) && (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,9 +99,9 @@ importers:
       autoprefixer:
         specifier: 10.5.4
         version: 10.5.4(postcss@8.5.25)
-      class-names:
-        specifier: 1.0.0
-        version: 1.0.0
+      clsx:
+        specifier: 2.1.1
+        version: 2.1.1
       daisyui:
         specifier: 5.7.7
         version: 5.7.7
@@ -3466,12 +3466,6 @@ packages:
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
-  class-names@1.0.0:
-    resolution: {integrity: sha512-AQL0OLcu6D5hTwPcY78UgQ0JMS5cR1eYFV60C6V9WNMKVgyXi+CSGYuuWUAVo/6+Z2JRk6VBTn1XO5U94SqBww==}
-
-  classnames@2.5.1:
-    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
-
   clean-stack@3.0.1:
     resolution: {integrity: sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==}
     engines: {node: '>=10'}
@@ -5307,10 +5301,6 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.24:
-    resolution: {integrity: sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.25:
@@ -10330,12 +10320,6 @@ snapshots:
 
   cjs-module-lexer@2.2.0: {}
 
-  class-names@1.0.0:
-    dependencies:
-      classnames: 2.5.1
-
-  classnames@2.5.1: {}
-
   clean-stack@3.0.1:
     dependencies:
       escape-string-regexp: 4.0.0
@@ -12298,12 +12282,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.24:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
@@ -13450,7 +13428,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.24
+      postcss: 8.5.25
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Replace the `class-names` dependency with `clsx` (2.1.1), the modern, smaller, actively-maintained standard for conditional className construction in React
- Update all 12 usage sites across components (Heading, LinkButton, ContactForm, Section, PopSuccess, Testimonial, Icon, and the Navbar family)
- Drop the stale `declare module 'class-names'` entry from `custom.d.ts` (clsx ships its own types)

Closes #649

## Test plan
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm type:check`
- [x] `pnpm build`
- [x] `pnpm test:e2e` (33 passed, 1 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced the class-name utility with `clsx` across form, navigation, layout, content, and UI components.
  * Preserved existing styling, rendering, component props, form behavior, and navigation interactions.
* **Chores**
  * Updated package configuration and type declarations to reflect the new class-name utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->