### PR TITLE
fix: pull phone number from site settings in FAQ and services metadata

### DIFF
--- a/packages/ses-next/src/app/faq/page.tsx
+++ b/packages/ses-next/src/app/faq/page.tsx
@@ -5,11 +5,10 @@ import { safeJsonLd } from '@/lib/structuredData';
 
 export async function generateMetadata(): Promise<Metadata> {
   const siteSettings = await getSiteSettings();
-  const { companyName } = siteSettings;
+  const { companyName, phone } = siteSettings;
   return {
     title: `Electrician FAQs Melbourne | Common Questions Answered | ${companyName}`,
-    description:
-      'Answers to common questions about electrical work in Melbourne — costs, safety, switchboards, solar & more. Licensed electricians, 5.0★ rated. Call (03) 4050 7937.',
+    description: `Answers to common questions about electrical work in Melbourne — costs, safety, switchboards, solar & more. Licensed electricians, 5.0★ rated. Call ${phone}.`,
     alternates: {
       canonical: '/faq',
     },

--- a/packages/ses-next/src/app/services/page.tsx
+++ b/packages/ses-next/src/app/services/page.tsx
@@ -9,20 +9,23 @@ import { safeJsonLd } from '@/lib/structuredData';
 import type { ServiceItem } from '@/types';
 
 const servicesTitle = 'Electrical Services Melbourne | Licensed Electricians | SES';
-const servicesDescription =
-  'Full-range electrical services in Melbourne — solar, air conditioning, switchboards, lighting & more. 5.0★ rated, REC 24794, 19 yrs experience. Call (03) 4050 7937.';
 
-export const metadata: Metadata = {
-  title: servicesTitle,
-  description: servicesDescription,
-  alternates: {
-    canonical: '/services',
-  },
-  openGraph: {
+export async function generateMetadata(): Promise<Metadata> {
+  const { phone } = await getSiteSettings();
+  const servicesDescription = `Full-range electrical services in Melbourne — solar, air conditioning, switchboards, lighting & more. 5.0★ rated, REC 24794, 19 yrs experience. Call ${phone}.`;
+
+  return {
     title: servicesTitle,
     description: servicesDescription,
-  },
-};
+    alternates: {
+      canonical: '/services',
+    },
+    openGraph: {
+      title: servicesTitle,
+      description: servicesDescription,
+    },
+  };
+}
 
 type ServiceCardProps = {
   service: ServiceItem;


### PR DESCRIPTION
## Summary
- FAQ and services page metadata descriptions had the old phone number `(03) 4050 7937` hardcoded
- Now both pull `phone` from `siteSettings` (Sanity) so they stay in sync with the CMS value
- Related: business phone number was just updated in Sanity to `0415 338 040` per client request (CallRail cancelled, now using mobile)

## Test plan
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm type:check`
- [x] `pnpm build`
- [x] `pnpm test:e2e` (33 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated FAQ and Services page descriptions to display the current phone number from site settings.
  - Improved consistency of contact information across page metadata, including search results and social sharing previews.
  - Preserved existing page titles, canonical URLs, and Open Graph details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->