### PR TITLE
ci: replace wait-for-vercel-preview with vercel/wait-for-deployment-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.62.0-jammy
     timeout-minutes: 10
+    permissions:
+      contents: read
+      deployments: read
+      statuses: read
 
     steps:
       - uses: actions/checkout@v7
@@ -45,16 +49,16 @@ jobs:
 
       - name: Wait for Vercel deployment
         id: vercel-deployment
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.3
+        uses: vercel/wait-for-deployment-action@0e2b0c5c5cce31f1648108aeec56467187aca037 # main
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 300
-          check_interval: 10
+          environment: preview
+          timeout: 300
+          check-interval: 10
 
       - name: Run Playwright tests
         run: pnpm --filter ses-next test:e2e
         env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.vercel-deployment.outputs.url }}
+          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.vercel-deployment.outputs.deployment-url }}
           REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
           HOME: /root
 


### PR DESCRIPTION
## Summary
- Swap the deprecated `patrickedqvist/wait-for-vercel-preview@v1.3.3` action for Vercel's own `vercel/wait-for-deployment-action`, pinned to commit `0e2b0c5c5cce31f1648108aeec56467187aca037` on `main` (the repo has no tagged releases yet).
- Auth now uses the ambient `GITHUB_TOKEN` instead of an explicit `token` input, so the job declares `deployments: read` and `statuses: read` permissions (plus `contents: read` for checkout).
- Update the downstream output reference from `outputs.url` to `outputs.deployment-url` to match the new action's output name.

## Test plan
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm type:check`
- [x] `pnpm build`
- [x] `pnpm test:e2e`
- [ ] Watch CI on this PR to confirm the new action correctly waits for and resolves the Vercel preview deployment URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3VxH5rcpKnswAxXqH67zF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved preview testing reliability by updating deployment readiness checks.
  * Added read-only permissions required for repository, deployment, and status access.
  * Updated deployment URL handling for browser-based preview tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->