### PR TITLE
fix: source homepage phone from siteSettings, remove duplicate field

### DIFF
--- a/packages/ses-content/schemas/homepage.ts
+++ b/packages/ses-content/schemas/homepage.ts
@@ -41,7 +41,6 @@ export default defineType({
           title: 'Call back',
           description: 'Appears in the contact form',
         },
-        {name: 'phone', type: 'string', title: 'Phone number'},
       ],
     }),
     defineField({

--- a/packages/ses-next/src/app/page.tsx
+++ b/packages/ses-next/src/app/page.tsx
@@ -172,6 +172,7 @@ export default async function Home() {
         <Contact
           contact={homepageContent.contact}
           location={googleMapsLocation}
+          phone={phone}
           streetAddress={streetAddress}
           suburb={suburb}
         />

--- a/packages/ses-next/src/components/Contact.tsx
+++ b/packages/ses-next/src/components/Contact.tsx
@@ -14,11 +14,12 @@ type ContactProps = {
   className?: string;
   contact: ContactContentModel;
   location: string | null;
+  phone: string;
   streetAddress?: string;
   suburb?: string;
 };
 
-export function Contact({ className, contact, location, streetAddress, suburb }: ContactProps) {
+export function Contact({ className, contact, location, phone, streetAddress, suburb }: ContactProps) {
   const { error, loading, messageSent, sendMessage } = useContact();
   const [firstBlurb = '', secondBlurb = ''] = contact.blurbs ?? [];
 
@@ -39,10 +40,10 @@ export function Contact({ className, contact, location, streetAddress, suburb }:
           </div>
         </div>
       </div>
-      <Activity mode={contact.phone ? 'visible' : 'hidden'}>
+      <Activity mode={phone ? 'visible' : 'hidden'}>
         <p className="mx-auto mb-12 max-w-screen-md px-4 text-center">
-          <LinkButton href={`tel:${contact.phone}`}>
-            <Icon name="phone" size="lg" /> {contact.phone}
+          <LinkButton href={`tel:${phone}`}>
+            <Icon name="phone" size="lg" /> {phone}
           </LinkButton>
         </p>
       </Activity>

--- a/packages/ses-next/src/lib/content/mappers.ts
+++ b/packages/ses-next/src/lib/content/mappers.ts
@@ -105,7 +105,6 @@ export const mapHomepageTraining = (model: HomepageContentModel): Training[] => 
 
 export const mapHomepageContact = (model: HomepageContentModel): ContactContentModel => {
   return {
-    phone: model.contact.phone,
     blurbs: model.contact.blurbs,
     callBack: model.contact.callBack,
   };

--- a/packages/ses-next/src/sanity/sanity.types.ts
+++ b/packages/ses-next/src/sanity/sanity.types.ts
@@ -384,7 +384,6 @@ export type Homepage = {
   contact?: {
     blurbs?: Array<string>;
     callBack?: string;
-    phone?: string;
   };
   services?: {
     blurbs?: Array<string>;

--- a/packages/ses-next/src/sanity/schema.json
+++ b/packages/ses-next/src/sanity/schema.json
@@ -2258,13 +2258,6 @@
                 "type": "string"
               },
               "optional": true
-            },
-            "phone": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string"
-              },
-              "optional": true
             }
           }
         },

--- a/packages/ses-next/src/types.ts
+++ b/packages/ses-next/src/types.ts
@@ -334,15 +334,12 @@ export const TermsAndConditionsSchema: z.ZodType<SanityTermsAndConditions> = z.o
   terms: SanityPortableTextSchema,
 });
 
-type SanityHomepageContact = NonNullable<SanityHomepageDoc['contact']>;
-
-export type ContactContentModel = Required<Pick<SanityHomepageContact, 'phone'>> & {
+export type ContactContentModel = {
   blurbs: string[] | null;
   callBack: string | null;
 };
 
 export const ContactSchema: z.ZodType<ContactContentModel> = z.object({
-  phone: z.string(),
   blurbs: z.array(z.string()).nullable(),
   callBack: z.string().nullable(),
 });


### PR DESCRIPTION
## Summary
- Removes the duplicate `contact.phone` field from the `homepage` Sanity schema — `siteSettings.phone` is now the single source of truth for the phone number shown on the site
- Updates `ContactContentModel`/`ContactSchema`, `mapHomepageContact`, and the `Contact` component to no longer read `phone` from homepage content
- `page.tsx` now passes `phone` into `<Contact>` from `siteSettings` (already fetched there for the navbar)
- Regenerated `sanity.types.ts` / `schema.json` via typegen

Closes #368

## Test plan
- [x] `pnpm format`
- [x] `pnpm lint` (0 errors, pre-existing warnings only)
- [x] `pnpm type:check`
- [x] `pnpm build`
- [x] `pnpm test:e2e` (33 passed, 1 skipped)
- [x] Verified `tel:` link renders correctly on homepage against a production build (`pnpm --filter ses-next start`)