### PR TITLE
engineering: extract reusable page layout primitives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,12 @@ hand-rolling wrapper `className` strings.
 - `Container` — the horizontal width + padding wrapper (`mx-auto px-4 sm:px-6
 lg:px-8`). Pick a `width`: `narrow` (`max-w-4xl`, e.g. the services hub),
   `standard` (`max-w-screen-xl`, e.g. FAQ/terms/error pages), `wide`
-  (`max-w-screen-lg`, e.g. prose articles and in-page sections), or `full`
-  (no cap, e.g. homepage sections nested in `Section`). Use `as` to render a
-  `section`, `article`, or `nav` instead of a `div`, and pass `className` for
-  one-off spacing (e.g. `mt-12 mb-8`) — never re-add a `max-w-*` or `px-*` here.
+  (`max-w-screen-lg`, e.g. prose articles and in-page sections), `expanded`
+  (`max-w-screen-2xl`, e.g. the image gallery), or `full` (no extra cap beyond
+  Tailwind's own `container` breakpoints, e.g. homepage sections nested in
+  `Section`). Use `as` to render a `section`, `article`, or `nav` instead of a
+  `div`, and pass `className` for one-off spacing (e.g. `mt-12 mb-8`) — never
+  re-add a `max-w-*` or `px-*` here.
 - `Section` (homepage-only) still owns the larger `py-16 md:py-24` rhythm for
   full-bleed sections on `/`; it composes with `Container` the same way.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,25 @@ To deploy the Sanity Studio schema, navigate to `packages/ses-content` and run:
 - The app folder should only contain routing components (page.tsx and route.ts)
 - Components that are relevant to a page, should still go in to the components folder
 
+## Layout
+
+Route pages and full-width sections should compose from the shared primitives in
+`src/components/Container.tsx` and `src/components/PageSection.tsx` rather than
+hand-rolling wrapper `className` strings.
+
+- `PageSection` — the `bg-base-100`/`bg-base-200` band with a route page's
+  standard vertical rhythm (`py-6 sm:py-8 lg:py-12`). Use `tone="muted"` for a
+  `bg-base-200` band.
+- `Container` — the horizontal width + padding wrapper (`mx-auto px-4 sm:px-6
+lg:px-8`). Pick a `width`: `narrow` (`max-w-4xl`, e.g. the services hub),
+  `standard` (`max-w-screen-xl`, e.g. FAQ/terms/error pages), `wide`
+  (`max-w-screen-lg`, e.g. prose articles and in-page sections), or `full`
+  (no cap, e.g. homepage sections nested in `Section`). Use `as` to render a
+  `section`, `article`, or `nav` instead of a `div`, and pass `className` for
+  one-off spacing (e.g. `mt-12 mb-8`) — never re-add a `max-w-*` or `px-*` here.
+- `Section` (homepage-only) still owns the larger `py-16 md:py-24` rhythm for
+  full-bleed sections on `/`; it composes with `Container` the same way.
+
 ## Theming
 
 Semantic theme tokens are the styling contract. Raw Tailwind palette utilities

--- a/packages/ses-next/src/app/error.tsx
+++ b/packages/ses-next/src/app/error.tsx
@@ -2,6 +2,8 @@
 
 import Link from 'next/link';
 
+import { Container, PageSection } from '@/components';
+
 export default function ErrorPage({
   error,
   unstable_retry,
@@ -10,8 +12,8 @@ export default function ErrorPage({
   unstable_retry: () => void;
 }) {
   return (
-    <div className="bg-base-100 py-6 sm:py-8 lg:py-12">
-      <div className="container mx-auto max-w-screen-xl px-4 md:px-8">
+    <PageSection>
+      <Container width="standard">
         <div className="mb-10 md:mb-16">
           <h1 className="text-base-content mb-4 text-center text-2xl font-bold md:mb-6 lg:text-3xl">Server Error</h1>
           <p className="text-base-content text-center text-lg">
@@ -27,7 +29,7 @@ export default function ErrorPage({
             </button>
           </div>
         </div>
-      </div>
-    </div>
+      </Container>
+    </PageSection>
   );
 }

--- a/packages/ses-next/src/app/faq/page.tsx
+++ b/packages/ses-next/src/app/faq/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 
+import { Container } from '@/components/Container';
+import { PageSection } from '@/components/PageSection';
 import { getFAQs, getSiteSettings } from '@/lib/content/contentService';
 import { safeJsonLd } from '@/lib/structuredData';
 
@@ -46,8 +48,8 @@ export default async function FaqPage() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(faqJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(breadcrumbJsonLd) }} />
-      <div className="bg-base-100 py-6 sm:py-8 lg:py-12">
-        <div className="container mx-auto max-w-screen-xl px-4 md:px-8">
+      <PageSection>
+        <Container width="standard">
           <div className="mb-10 md:mb-16">
             <h1 className="text-base-content mb-4 text-center text-2xl font-bold md:mb-6 lg:text-3xl">
               Frequently asked questions
@@ -67,8 +69,8 @@ export default async function FaqPage() {
               </div>
             ))}
           </div>
-        </div>
-      </div>
+        </Container>
+      </PageSection>
     </>
   );
 }

--- a/packages/ses-next/src/app/locations/[locationSlug]/page.tsx
+++ b/packages/ses-next/src/app/locations/[locationSlug]/page.tsx
@@ -7,7 +7,9 @@ import type { PortableTextComponents } from '@portabletext/react';
 
 import { getAllLocationPages, getLocationPageBySlug, getSiteSettings } from '@/lib/content/contentService';
 import { faqJsonLd, safeJsonLd } from '@/lib/structuredData';
+import { Container } from '@/components/Container';
 import { CustomImage } from '@/components/CustomImage';
+import { PageSection } from '@/components/PageSection';
 import { ServiceBreadcrumb } from '@/components/ServiceBreadcrumb/ServiceBreadcrumb';
 import { LocationNearbySuburbs } from '@/components/LocationNearbySuburbs/LocationNearbySuburbs';
 import { LocationServices } from '@/components/LocationServices/LocationServices';
@@ -130,11 +132,11 @@ export default async function LocationPage({ params }: LocationPageProps) {
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(faqJsonLd(page.faqs)) }} />
       )}
       <ServiceBreadcrumb items={breadcrumbItems} />
-      <div className="bg-base-100 py-6 sm:py-8 lg:py-12">
-        <article className="prose lg:prose-lg mx-auto max-w-screen-lg px-4 md:px-8">
+      <PageSection>
+        <Container width="wide" as="article" className="prose lg:prose-lg">
           <h1 className="text-center">Electrician {page.suburb}</h1>
           {page.intro && <PortableText value={page.intro} components={portableTextComponents} />}
-        </article>
+        </Container>
 
         {page.services.length > 0 && <LocationServices services={page.services} />}
 
@@ -143,7 +145,7 @@ export default async function LocationPage({ params }: LocationPageProps) {
         )}
 
         {page.faqs.length > 0 && <LocationFaqs faqs={page.faqs} suburb={page.suburb} />}
-      </div>
+      </PageSection>
     </>
   );
 }

--- a/packages/ses-next/src/app/locations/page.tsx
+++ b/packages/ses-next/src/app/locations/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { Container } from '@/components/Container';
 import { getAllLocationPages, getSiteSettings } from '@/lib/content/contentService';
 import { ServiceBreadcrumb } from '@/components/ServiceBreadcrumb/ServiceBreadcrumb';
 import { safeJsonLd } from '@/lib/structuredData';
@@ -112,18 +113,18 @@ export default async function LocationsIndexPage() {
           }}
           aria-hidden="true"
         />
-        <div className="mx-auto max-w-screen-lg px-4 py-12 text-center md:px-8 md:py-16">
+        <Container width="wide" className="py-12 text-center md:py-16">
           <p className="text-primary mb-3 text-sm font-semibold tracking-widest uppercase">Melbourne&apos;s West</p>
           <h1 className="text-base-content mb-4 text-4xl font-extrabold sm:text-5xl">Areas We Serve</h1>
           <p className="text-base-content/70 mx-auto max-w-xl text-lg">
             Based in Altona North, we service Melbourne&apos;s western suburbs. Select your suburb below for local
             electricians, solar, and air conditioning.
           </p>
-        </div>
+        </Container>
       </div>
 
       {/* Suburb grid */}
-      <div className="mx-auto max-w-screen-lg px-4 pb-16 md:px-8">
+      <Container width="wide" className="pb-16">
         {pages.length > 0 ? (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {pages.map((page) => (
@@ -133,11 +134,11 @@ export default async function LocationsIndexPage() {
         ) : (
           <p className="text-base-content/70 py-12 text-center">Location pages coming soon.</p>
         )}
-      </div>
+      </Container>
 
       {/* CTA strip */}
       <section aria-labelledby="locations-cta-heading" className="border-primary/10 bg-primary/5 border-t">
-        <div className="mx-auto flex max-w-screen-lg flex-col items-center justify-between gap-6 px-4 py-12 sm:flex-row md:px-8">
+        <Container width="wide" className="flex flex-col items-center justify-between gap-6 py-12 sm:flex-row">
           <div>
             <h2 id="locations-cta-heading" className="text-base-content text-xl font-bold">
               Don&apos;t see your suburb?
@@ -149,7 +150,7 @@ export default async function LocationsIndexPage() {
           <a href={`tel:${phone}`} className="btn btn-primary whitespace-nowrap" aria-label={`Call us on ${phone}`}>
             {phone}
           </a>
-        </div>
+        </Container>
       </section>
     </>
   );

--- a/packages/ses-next/src/app/not-found.tsx
+++ b/packages/ses-next/src/app/not-found.tsx
@@ -1,10 +1,12 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { Container, PageSection } from '@/components';
+
 export default function NotFound() {
   return (
-    <div className="bg-base-100 py-6 sm:py-8 lg:py-12">
-      <div className="container mx-auto max-w-screen-xl px-4 md:px-8">
+    <PageSection>
+      <Container width="standard">
         <div className="mb-10 md:mb-16">
           <h1 className="text-base-content mb-4 text-center text-2xl font-bold md:mb-6 lg:text-3xl">Page not found</h1>
           <Image src="/not-found.jpg" alt="404 - Not Found" width={600} height={400} className="mx-auto" />
@@ -15,7 +17,7 @@ export default function NotFound() {
             </Link>
           </p>
         </div>
-      </div>
-    </div>
+      </Container>
+    </PageSection>
   );
 }

--- a/packages/ses-next/src/app/services/[...slug]/page.tsx
+++ b/packages/ses-next/src/app/services/[...slug]/page.tsx
@@ -13,8 +13,10 @@ import {
   getSiteSettings,
 } from '@/lib/content/contentService';
 import { faqJsonLd, safeJsonLd } from '@/lib/structuredData';
+import { Container } from '@/components/Container';
 import { CustomImage } from '@/components/CustomImage';
 import { ImageCarousel } from '@/components/ImageCarousel';
+import { PageSection } from '@/components/PageSection';
 import { RelatedServices } from '@/components/RelatedServices/RelatedServices';
 import { ServiceLocations } from '@/components/ServiceLocations/ServiceLocations';
 import { SanityImage } from '@/components/SanityImage';
@@ -211,11 +213,11 @@ export default async function ServicePage({ params }: ServicePageProps) {
       )}
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(breadcrumbJsonLd) }} />
       <ServiceBreadcrumb items={breadcrumbItems} />
-      <div className="bg-base-100 py-6 sm:py-8 lg:py-12">
-        <article className="prose lg:prose-lg mx-auto max-w-screen-lg px-4 md:px-8">
+      <PageSection>
+        <Container width="wide" as="article" className="prose lg:prose-lg">
           <h1 className="text-center">{service.name}</h1>
           {service.content && <PortableText value={service.content} components={portableTextComponents} />}
-        </article>
+        </Container>
         {service.imageGallery && <ImageCarousel images={service.imageGallery} serviceName={service.name} />}
 
         {childServices.length > 0 && <RelatedServices services={childServices} />}
@@ -223,7 +225,7 @@ export default async function ServicePage({ params }: ServicePageProps) {
         {locationPages.length > 0 && <ServiceLocations serviceName={service.name} locations={locationPages} />}
 
         {service.faqs && service.faqs.length > 0 && (
-          <section aria-labelledby="faq-heading" className="mx-auto mt-12 mb-8 max-w-screen-lg px-4 md:px-8">
+          <Container width="wide" as="section" className="mt-12 mb-8" aria-labelledby="faq-heading">
             <h2 id="faq-heading" className="text-base-content mb-6 text-3xl font-bold">
               Frequently Asked Questions
             </h2>
@@ -235,11 +237,11 @@ export default async function ServicePage({ params }: ServicePageProps) {
                 </div>
               ))}
             </dl>
-          </section>
+          </Container>
         )}
 
         {filteredBlogPosts.length > 0 && (
-          <div className="mx-auto mt-12 mb-8 max-w-screen-lg px-4 md:px-8">
+          <Container width="wide" className="mt-12 mb-8">
             <h2 className="text-base-content mb-2 text-3xl font-bold">Related Blog Posts</h2>
             <p className="text-base-content/70 mb-6">Explore our {service.name.toLowerCase()} articles and insights</p>
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
@@ -277,9 +279,9 @@ export default async function ServicePage({ params }: ServicePageProps) {
                 </Link>
               ))}
             </div>
-          </div>
+          </Container>
         )}
-      </div>
+      </PageSection>
     </>
   );
 }

--- a/packages/ses-next/src/app/services/page.tsx
+++ b/packages/ses-next/src/app/services/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { Container } from '@/components/Container';
 import { Heading } from '@/components/Heading';
 import { Icon } from '@/components/Icon/Icon';
+import { PageSection } from '@/components/PageSection';
 import { SanityImage } from '@/components/SanityImage';
 import { getAllLocationPages, getServicesHubContent, getSiteSettings, getServices } from '@/lib/content/contentService';
 import { safeJsonLd } from '@/lib/structuredData';
@@ -109,8 +111,8 @@ export default async function ServicesHubPage() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(collectionPageJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(breadcrumbJsonLd) }} />
-      <div className="bg-base-100 py-6 sm:py-8 lg:py-12">
-        <div className="container mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+      <PageSection>
+        <Container width="narrow">
           <div className="mx-auto mb-12 max-w-2xl text-center">
             <p className="text-secondary mb-3 text-sm font-semibold tracking-[0.2em] uppercase">Service Directory</p>
             <Heading level={1}>{hubContent.heading ?? 'Our Services'}</Heading>
@@ -173,8 +175,8 @@ export default async function ServicesHubPage() {
               </Link>
             </div>
           </section>
-        </div>
-      </div>
+        </Container>
+      </PageSection>
     </>
   );
 }

--- a/packages/ses-next/src/app/terms/page.tsx
+++ b/packages/ses-next/src/app/terms/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { PortableText } from '@portabletext/react';
 
-import { CustomImage } from '@/components';
+import { Container, CustomImage, PageSection } from '@/components';
 import { getTermsAndConditions, getSiteSettings } from '@/lib/content/contentService';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -25,8 +25,8 @@ export default async function TermsPage() {
   }
 
   return (
-    <div className="bg-base-100 py-6 sm:py-8 lg:py-12">
-      <div className="container mx-auto max-w-screen-xl px-4 md:px-8">
+    <PageSection>
+      <Container width="standard">
         <div className="mb-10 md:mb-16">
           <h1 className="text-base-content mb-4 text-center text-2xl font-bold md:mb-6 lg:text-3xl">
             Terms of Service
@@ -42,7 +42,7 @@ export default async function TermsPage() {
             />
           </div>
         </div>
-      </div>
-    </div>
+      </Container>
+    </PageSection>
   );
 }

--- a/packages/ses-next/src/components/Container.tsx
+++ b/packages/ses-next/src/components/Container.tsx
@@ -1,9 +1,29 @@
 import React from 'react';
+import { clsx } from 'clsx';
 
-interface ContainerProps {
+type ContainerWidth = 'full' | 'narrow' | 'standard' | 'wide';
+type ContainerElement = 'div' | 'article' | 'section' | 'nav';
+
+interface ContainerOwnProps {
+  width?: ContainerWidth;
+  as?: ContainerElement;
+  className?: string;
   children: React.ReactNode;
 }
 
-export function Container({ children }: ContainerProps) {
-  return <div className="container mx-auto px-4 sm:px-6 lg:px-8">{children}</div>;
+type ContainerProps = ContainerOwnProps & Omit<React.ComponentPropsWithoutRef<'div'>, keyof ContainerOwnProps>;
+
+const widthStyles: Record<ContainerWidth, string> = {
+  full: '',
+  narrow: 'max-w-4xl',
+  standard: 'max-w-screen-xl',
+  wide: 'max-w-screen-lg',
+};
+
+export function Container({ width = 'full', as: Tag = 'div', className, children, ...rest }: ContainerProps) {
+  return (
+    <Tag className={clsx('container mx-auto px-4 sm:px-6 lg:px-8', widthStyles[width], className)} {...rest}>
+      {children}
+    </Tag>
+  );
 }

--- a/packages/ses-next/src/components/Container.tsx
+++ b/packages/ses-next/src/components/Container.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { clsx } from 'clsx';
 
-type ContainerWidth = 'full' | 'narrow' | 'standard' | 'wide';
+type ContainerWidth = 'full' | 'narrow' | 'standard' | 'wide' | 'expanded';
 type ContainerElement = 'div' | 'article' | 'section' | 'nav';
 
 interface ContainerOwnProps {
@@ -18,6 +18,7 @@ const widthStyles: Record<ContainerWidth, string> = {
   narrow: 'max-w-4xl',
   standard: 'max-w-screen-xl',
   wide: 'max-w-screen-lg',
+  expanded: 'max-w-screen-2xl',
 };
 
 export function Container({ width = 'full', as: Tag = 'div', className, children, ...rest }: ContainerProps) {

--- a/packages/ses-next/src/components/Gallery.tsx
+++ b/packages/ses-next/src/components/Gallery.tsx
@@ -1,3 +1,4 @@
+import { Container } from '@/components/Container';
 import { PageSection } from '@/components/PageSection';
 import { SanityImage } from '@/components/SanityImage';
 
@@ -15,7 +16,7 @@ export function Gallery({ imageGallery }: GalleryProps) {
   return (
     <>
       <PageSection>
-        <div className="mx-auto max-w-screen-2xl px-4 md:px-8">
+        <Container width="expanded">
           <h2 className="font-display text-base-content mb-8 text-center text-2xl font-bold md:mb-12 lg:text-3xl">
             Gallery
           </h2>
@@ -40,7 +41,7 @@ export function Gallery({ imageGallery }: GalleryProps) {
               </div>
             ))}
           </div>
-        </div>
+        </Container>
       </PageSection>
     </>
   );

--- a/packages/ses-next/src/components/Gallery.tsx
+++ b/packages/ses-next/src/components/Gallery.tsx
@@ -1,3 +1,4 @@
+import { PageSection } from '@/components/PageSection';
 import { SanityImage } from '@/components/SanityImage';
 
 interface GalleryImage {
@@ -13,7 +14,7 @@ interface GalleryProps {
 export function Gallery({ imageGallery }: GalleryProps) {
   return (
     <>
-      <div className="bg-base-100 py-6 sm:py-8 lg:py-12">
+      <PageSection>
         <div className="mx-auto max-w-screen-2xl px-4 md:px-8">
           <h2 className="font-display text-base-content mb-8 text-center text-2xl font-bold md:mb-12 lg:text-3xl">
             Gallery
@@ -40,7 +41,7 @@ export function Gallery({ imageGallery }: GalleryProps) {
             ))}
           </div>
         </div>
-      </div>
+      </PageSection>
     </>
   );
 }

--- a/packages/ses-next/src/components/LocationFaqs/LocationFaqs.tsx
+++ b/packages/ses-next/src/components/LocationFaqs/LocationFaqs.tsx
@@ -1,3 +1,4 @@
+import { Container } from '@/components/Container';
 import type { LocationPageFaq } from '@/types';
 
 type LocationFaqsProps = {
@@ -7,7 +8,7 @@ type LocationFaqsProps = {
 
 export function LocationFaqs({ faqs, suburb }: LocationFaqsProps) {
   return (
-    <section aria-labelledby="location-faq-heading" className="mx-auto mt-12 mb-8 max-w-screen-lg px-4 md:px-8">
+    <Container width="wide" as="section" className="mt-12 mb-8" aria-labelledby="location-faq-heading">
       <h2 id="location-faq-heading" className="text-base-content mb-6 text-3xl font-bold">
         Frequently Asked Questions — {suburb}
       </h2>
@@ -19,6 +20,6 @@ export function LocationFaqs({ faqs, suburb }: LocationFaqsProps) {
           </div>
         ))}
       </dl>
-    </section>
+    </Container>
   );
 }

--- a/packages/ses-next/src/components/LocationNearbySuburbs/LocationNearbySuburbs.tsx
+++ b/packages/ses-next/src/components/LocationNearbySuburbs/LocationNearbySuburbs.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { Container } from '@/components/Container';
 import type { LocationPageNearbySuburbRef } from '@/types';
 
 type LocationNearbySuburbsProps = {
@@ -9,7 +10,7 @@ type LocationNearbySuburbsProps = {
 
 export function LocationNearbySuburbs({ suburb, nearbySuburbs }: LocationNearbySuburbsProps) {
   return (
-    <section aria-labelledby="nearby-suburbs-heading" className="mx-auto mt-16 mb-12 max-w-5xl px-4 md:px-8">
+    <Container width="wide" as="section" className="mt-16 mb-12" aria-labelledby="nearby-suburbs-heading">
       <div className="surface-card bg-ambient relative overflow-hidden rounded-xl px-6 py-8 sm:px-8 lg:px-10">
         <div className="relative grid gap-8 lg:grid-cols-2 lg:items-start">
           <div className="max-w-xl">
@@ -56,6 +57,6 @@ export function LocationNearbySuburbs({ suburb, nearbySuburbs }: LocationNearbyS
           </div>
         </div>
       </div>
-    </section>
+    </Container>
   );
 }

--- a/packages/ses-next/src/components/LocationServices/LocationServices.tsx
+++ b/packages/ses-next/src/components/LocationServices/LocationServices.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { Container } from '@/components/Container';
 import { Icon } from '@/components/Icon/Icon';
 import type { LocationPageServiceRef } from '@/types';
 
@@ -15,7 +16,7 @@ const getServicePath = (service: LocationPageServiceRef): string => {
 
 export function LocationServices({ services }: LocationServicesProps) {
   return (
-    <section aria-labelledby="location-services-heading" className="mx-auto mt-12 mb-8 max-w-screen-lg px-4 md:px-8">
+    <Container width="wide" as="section" className="mt-12 mb-8" aria-labelledby="location-services-heading">
       <h2 id="location-services-heading" className="text-base-content mb-6 text-3xl font-bold">
         Services We Offer
       </h2>
@@ -43,6 +44,6 @@ export function LocationServices({ services }: LocationServicesProps) {
           </article>
         ))}
       </div>
-    </section>
+    </Container>
   );
 }

--- a/packages/ses-next/src/components/PageSection.tsx
+++ b/packages/ses-next/src/components/PageSection.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { clsx } from 'clsx';
+
+type PageSectionTone = 'base' | 'muted';
+
+interface PageSectionProps {
+  tone?: PageSectionTone;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const toneStyles: Record<PageSectionTone, string> = {
+  base: 'bg-base-100',
+  muted: 'bg-base-200',
+};
+
+export function PageSection({ tone = 'base', className, children }: PageSectionProps) {
+  return <div className={clsx(toneStyles[tone], 'py-6 sm:py-8 lg:py-12', className)}>{children}</div>;
+}

--- a/packages/ses-next/src/components/RelatedServices/RelatedServices.tsx
+++ b/packages/ses-next/src/components/RelatedServices/RelatedServices.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { Container } from '@/components/Container';
 import { Icon } from '@/components/Icon/Icon';
 import type { ServiceItem } from '@/types';
 
@@ -15,7 +16,7 @@ const getServicePath = (service: ServiceItem): string => {
 
 export function RelatedServices({ services }: RelatedServicesProps) {
   return (
-    <section aria-labelledby="related-services-heading" className="mx-auto mt-12 mb-8 max-w-screen-lg px-4 md:px-8">
+    <Container width="wide" as="section" className="mt-12 mb-8" aria-labelledby="related-services-heading">
       <h2 id="related-services-heading" className="text-base-content mb-6 text-3xl font-bold">
         Specialist Services
       </h2>
@@ -43,6 +44,6 @@ export function RelatedServices({ services }: RelatedServicesProps) {
           </article>
         ))}
       </div>
-    </section>
+    </Container>
   );
 }

--- a/packages/ses-next/src/components/ServiceAreas.tsx
+++ b/packages/ses-next/src/components/ServiceAreas.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { Container } from '@/components/Container';
 import type { ServiceAreaRef } from '@/types';
 
 const sectionTitle = "Serving Melbourne's Western Suburbs";
@@ -12,7 +13,7 @@ export function ServiceAreas({ areas }: ServiceAreasProps) {
   if (areas.length === 0) return null;
 
   return (
-    <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+    <Container width="wide">
       <div className="flex flex-col items-center gap-6">
         <div className="flex items-center gap-4">
           <span className="bg-base-300 h-px w-12" aria-hidden="true" />
@@ -38,6 +39,6 @@ export function ServiceAreas({ areas }: ServiceAreasProps) {
           ))}
         </ul>
       </div>
-    </div>
+    </Container>
   );
 }

--- a/packages/ses-next/src/components/ServiceBreadcrumb/ServiceBreadcrumb.tsx
+++ b/packages/ses-next/src/components/ServiceBreadcrumb/ServiceBreadcrumb.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link';
 
+import { Container } from '@/components/Container';
+
 interface BreadcrumbItem {
   name: string;
   item?: string;
@@ -11,7 +13,7 @@ interface ServiceBreadcrumbProps {
 
 export function ServiceBreadcrumb({ items }: ServiceBreadcrumbProps) {
   return (
-    <nav aria-label="Breadcrumb" className="mx-auto max-w-screen-lg px-4 pt-4 md:px-8">
+    <Container width="wide" as="nav" className="pt-4" aria-label="Breadcrumb">
       <ol className="text-base-content/70 flex flex-wrap items-center gap-1 text-sm">
         {items.map((item, index) => {
           const isLast = index === items.length - 1;
@@ -31,6 +33,6 @@ export function ServiceBreadcrumb({ items }: ServiceBreadcrumbProps) {
           );
         })}
       </ol>
-    </nav>
+    </Container>
   );
 }

--- a/packages/ses-next/src/components/ServiceLocations/ServiceLocations.tsx
+++ b/packages/ses-next/src/components/ServiceLocations/ServiceLocations.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { Container } from '@/components/Container';
 import type { LocationPageNearbySuburbRef } from '@/types';
 
 type ServiceLocationsProps = {
@@ -21,7 +22,7 @@ const getCardSpanClass = (index: number): string => {
  */
 export function ServiceLocations({ serviceName, locations }: ServiceLocationsProps) {
   return (
-    <section aria-labelledby="service-locations-heading" className="mx-auto mt-14 mb-10 max-w-screen-xl px-4 md:px-8">
+    <Container width="standard" as="section" className="mt-14 mb-10" aria-labelledby="service-locations-heading">
       <div className="bg-neutral text-neutral-content relative overflow-hidden rounded-3xl px-6 py-10 shadow-2xl sm:px-8 lg:px-10">
         <div className="bg-secondary/25 absolute -top-16 -right-10 h-44 w-44 rounded-full blur-3xl" />
         <div className="bg-primary/25 absolute -bottom-20 -left-10 h-56 w-56 rounded-full blur-3xl" />
@@ -66,6 +67,6 @@ export function ServiceLocations({ serviceName, locations }: ServiceLocationsPro
           </ul>
         </div>
       </div>
-    </section>
+    </Container>
   );
 }

--- a/packages/ses-next/src/components/Team.tsx
+++ b/packages/ses-next/src/components/Team.tsx
@@ -1,4 +1,6 @@
+import { Container } from '@/components/Container';
 import { Heading } from '@/components/Heading';
+import { PageSection } from '@/components/PageSection';
 import { SanityImage } from '@/components/SanityImage';
 import { Icon } from '@/components/Icon/Icon';
 import type { Training } from '@/types';
@@ -20,8 +22,8 @@ export function Team({ blurbs, members, training }: TeamProps) {
 
   return (
     <>
-      <div className="bg-base-200 py-6 sm:py-8 lg:py-12">
-        <div className="mx-auto max-w-screen-xl px-4 md:px-8">
+      <PageSection tone="muted">
+        <Container width="standard">
           <div className="mb-10 md:mb-16">
             <Heading level={2}>Meet our Team</Heading>
             <p className="text-base-content/70 mx-auto max-w-screen-md text-center md:text-lg">{firstBlurb}</p>
@@ -45,7 +47,7 @@ export function Team({ blurbs, members, training }: TeamProps) {
               </div>
             ))}
           </div>
-        </div>
+        </Container>
 
         <div className="mt-12 p-12">
           <p className="text-base-content/70 mx-auto max-w-screen-md text-center md:text-lg">{secondBlurb}</p>
@@ -58,7 +60,7 @@ export function Team({ blurbs, members, training }: TeamProps) {
             </div>
           ))}
         </div>
-      </div>
+      </PageSection>
     </>
   );
 }

--- a/packages/ses-next/src/components/TrustSignals.tsx
+++ b/packages/ses-next/src/components/TrustSignals.tsx
@@ -1,3 +1,4 @@
+import { Container } from '@/components/Container';
 import { Icon } from '@/components/Icon/Icon';
 import type { TrustSignal } from '@/types';
 
@@ -9,7 +10,7 @@ export function TrustSignals({ signals }: TrustSignalsProps) {
   if (signals.length === 0) return null;
 
   return (
-    <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+    <Container width="wide">
       <ul className="grid grid-cols-2 gap-3 lg:grid-cols-4">
         {signals.map((signal) => (
           <li
@@ -26,6 +27,6 @@ export function TrustSignals({ signals }: TrustSignalsProps) {
           </li>
         ))}
       </ul>
-    </div>
+    </Container>
   );
 }

--- a/packages/ses-next/src/components/index.ts
+++ b/packages/ses-next/src/components/index.ts
@@ -18,6 +18,7 @@ export { ImageCarousel } from './ImageCarousel';
 export { LinkButton } from './LinkButton';
 export { Modal } from './Modal';
 export { Navbar } from './Navbar/Navbar';
+export { PageSection } from './PageSection';
 export { PopSuccess } from './PopSuccess';
 export { Rating } from './Rating';
 export { RelatedServices } from './RelatedServices/RelatedServices';


### PR DESCRIPTION
## Summary
- Adds `Container` (width tiers: `narrow`/`standard`/`wide`/`full`, polymorphic `as` for `div`/`article`/`section`/`nav`) and `PageSection` (the repeated `bg-base-100`/`bg-base-200` route-page band) so pages stop hand-rolling `max-w-*`/`px-*` wrapper class strings.
- Refactors `faq`, `terms`, `error`, `not-found`, the services hub, service/location detail pages, and the locations index — plus their child sections (`LocationServices`, `LocationFaqs`, `RelatedServices`, `ServiceLocations`, `LocationNearbySuburbs`, `ServiceBreadcrumb`, `Team`, `Gallery`, `ServiceAreas`, `TrustSignals`) — onto the shared primitives.
- Consolidates a couple of duplicate width tokens along the way (`max-w-5xl` and `max-w-screen-lg` were both 1024px), and standardizes horizontal padding onto the existing `px-4 sm:px-6 lg:px-8` scale used elsewhere.
- Documents the convention in `AGENTS.md` under a new `## Layout` section.

Closes #640

## Test plan
- [x] `pnpm format`
- [x] `pnpm --filter ses-next lint`
- [x] `pnpm --filter ses-next type:check`
- [x] `pnpm --filter ses-next build`
- [x] `pnpm --filter ses-next test:e2e` (33 passed, 1 pre-existing skip)
- [x] Manual visual check (built + `next start`) of `/faq`, `/terms`, `/not-found`, `/services`, `/locations`, `/locations/electrician-altona`, `/services/lighting`, and `/` — no visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3VxH5rcpKnswAxXqH67zF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared layout components supporting consistent content widths, responsive spacing, background tones, and semantic HTML elements.
  * Added configurable container widths and rendering options for flexible page structure.
* **Improvements**
  * Updated site pages and sections to use standardized layouts, including FAQs, services, locations, galleries, team content, and informational pages.
* **Documentation**
  * Documented layout component usage, spacing, width, tone, and page-specific conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->